### PR TITLE
Flesh out "introduction" section of the docs 

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -9,4 +9,4 @@ In "Integrated" mode, cardwire uses eBPF LSM hooks to block applications from ac
 
 ## Getting Started
 
-Before proceeding, take a look at the [requirements](getting-started/requirements.md) to make sure your system is supported.
+To get started with cardwire, please take a look at the [requirements](getting-started/requirements.md) to make sure your system is supported, and then head over to [the installation instructions](getting-started/installation.md) 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,11 +1,11 @@
 # Introduction
 
-Cardwire is GPU manager for linux that uses eBPF LSM hooks to block GPUs
+Cardwire is GPU manager for Linux systems with Hybrid GPU configurations which allows users to smoothly and safely switch between "integrated" and "hybrid" GPU modes. It was created as a successor to the deprecated [supergfxctl](https://gitlab.com/asus-linux/supergfxctl) project.
 
-It was made to be a successor to the deprecated supergfxctl
+In "Integrated" mode, cardwire uses eBPF LSM hooks to block applications from accessing dedicated GPUs. This saves power by preventing the GPU from being woken up and allowing it to enter an extremely energy-efficient sleep state (`D3Cold`). In "Hybrid" mode, these blocks are removed and the system functions as it usually would. Switching is fast and does not require reboots or logouts to take effect. 
 
 > [!CAUTION]
-> Cardwire is in an early development stage, expect breaking changes and unstability.
+> Cardwire is in an early development stage, expect breaking changes and instability.
 
 ## Getting Started
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Cardwire is GPU manager for Linux systems with Hybrid GPU configurations which allows users to smoothly and safely switch between "integrated" and "hybrid" GPU modes. It was created as a successor to the deprecated [supergfxctl](https://gitlab.com/asus-linux/supergfxctl) project.
+Cardwire is GPU manager for Linux systems with multiple GPUs. It allows users to smoothly and safely switch between "integrated" and "hybrid" GPU modes. It was created as a successor to the deprecated [supergfxctl](https://gitlab.com/asus-linux/supergfxctl) project.
 
 In "Integrated" mode, cardwire uses eBPF LSM hooks to block applications from accessing dedicated GPUs. This saves power by preventing the GPU from being woken up and allowing it to enter an extremely energy-efficient sleep state (`D3Cold`). In "Hybrid" mode, these blocks are removed and the system functions as it usually would. As a safety option and for users who require more granular control, cardwire additionally allows users to manually block and unblock individual GPUs by ID. Switching is fast and does not require reboots or logouts to take effect. 
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,11 +2,11 @@
 
 Cardwire is GPU manager for Linux systems with Hybrid GPU configurations which allows users to smoothly and safely switch between "integrated" and "hybrid" GPU modes. It was created as a successor to the deprecated [supergfxctl](https://gitlab.com/asus-linux/supergfxctl) project.
 
-In "Integrated" mode, cardwire uses eBPF LSM hooks to block applications from accessing dedicated GPUs. This saves power by preventing the GPU from being woken up and allowing it to enter an extremely energy-efficient sleep state (`D3Cold`). In "Hybrid" mode, these blocks are removed and the system functions as it usually would. Switching is fast and does not require reboots or logouts to take effect. 
+In "Integrated" mode, cardwire uses eBPF LSM hooks to block applications from accessing dedicated GPUs. This saves power by preventing the GPU from being woken up and allowing it to enter an extremely energy-efficient sleep state (`D3Cold`). In "Hybrid" mode, these blocks are removed and the system functions as it usually would. As a safety option and for users who require more granular control, cardwire additionally allows users to manually block and unblock individual GPUs by ID. Switching is fast and does not require reboots or logouts to take effect. 
 
 > [!CAUTION]
 > Cardwire is in an early development stage, expect breaking changes and instability.
 
 ## Getting Started
 
-To get started with cardwire, please take a look at the [requirements](getting-started/requirements.md) to make sure your system is supported, and then head over to [the installation instructions](getting-started/installation.md) 
+To get started with cardwire, please take a look at the [requirements](getting-started/requirements.md) to make sure your system is supported, and then head over to [the installation instructions](getting-started/installation.md). 


### PR DESCRIPTION
- Fleshes out the introduction to explain in more detail what cardwire is and how it works 
- Fixes a typo ("unstability")
- Adds a direct link to the installation instructions
