### PR TITLE
Make get_fdo_apps errors recoverable

### DIFF
--- a/crates/cardwire-daemon/src/analyzer/static_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/static_analysis.rs
@@ -16,18 +16,24 @@ pub async fn get_fdo_apps() -> anyhow::Result<HashMap<String, bool>> {
             app_directories.push(path);
         }
     }
+
+    // Read /home to get a list of users
     if let Ok(home_entries) = fs::read_dir("/home") {
         for entry in home_entries.flatten() {
+            // if it's a dir
             if let Ok(file_type) = entry.file_type()
                 && file_type.is_dir()
             {
+                // store the home path of the user, eg: /home/john/
                 let mut user_app_dir = entry.path();
+                // .desktop often reside in this directory
                 user_app_dir.push(".local/share/applications");
 
                 if user_app_dir.exists() && user_app_dir.is_dir() {
                     app_directories.push(user_app_dir);
                 }
 
+                // this is for flatpaks .desktop
                 let mut user_flatpak_dir = entry.path();
                 user_flatpak_dir.push(".local/share/flatpak/exports/share/applications");
                 if user_flatpak_dir.exists() && user_flatpak_dir.is_dir() {
@@ -36,20 +42,30 @@ pub async fn get_fdo_apps() -> anyhow::Result<HashMap<String, bool>> {
             }
         }
     }
+    // Now read the paths to get the .desktop entries
     let mut app_list: HashMap<String, bool> = HashMap::new();
     let locales = get_languages_from_env();
+
     for app_directory in app_directories {
-        for app in app_directory.read_dir()? {
-            let app = app?;
-            let path = app.path();
-            if let Some(ext) = path.extension()
-                && ext == "desktop"
-            {
-                let app_fdo = DesktopEntry::from_path(path, Some(&locales)).unwrap();
-                if app_fdo.prefers_non_default_gpu()
-                    && let Some(flatpak_id) = app_fdo.flatpak()
+        // if directory is readable proceed, else just ignore it
+        if let Ok(app_directory) = app_directory.read_dir() {
+            // each file is an app entry
+            for app in app_directory {
+                let app = app?;
+                let path = app.path();
+                // ignore if app doesnt end with .desktop
+                if let Some(ext) = path.extension()
+                    && ext == "desktop"
                 {
-                    app_list.insert(flatpak_id.to_string(), true);
+                    // for now, only keep flatpak apps that prefers a non default gpu
+                    // the reason we only keep flatpak apps is because i can match a process with
+                    // it's FLATPAK_ID env
+                    if let Ok(app_fdo) = DesktopEntry::from_path(path, Some(&locales))
+                        && app_fdo.prefers_non_default_gpu()
+                        && let Some(flatpak_id) = app_fdo.flatpak()
+                    {
+                        app_list.insert(flatpak_id.to_string(), true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
if a directory or a .desktop file is not readable, just skip it