### PR TITLE
Docs: Add Ubuntu, consistent steps for BPF LSM and note on already open GPU file descriptors

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,12 +8,10 @@ using AUR:
 yay -S cardwire
 ```
 
-then enable and start the service
+Then [enable BPF LSM](#enabling-bpf-lsm) and start the service:
 
 ```bash
-sudo systemctl enable cardwired.service
-
-sudo systemctl start cardwired.service
+sudo systemctl enable cardwired --now
 ```
 
 ## Nix
@@ -28,6 +26,8 @@ cardwire = {
     inputs.nixpkgs.follows = "nixpkgs";
 };
 ```
+
+The NixOS module configures BPF LSM automatically — no manual kernel parameter changes needed.
 
 configuration.nix:
 
@@ -51,15 +51,82 @@ Using Terra
 
 ```bash
 sudo dnf install cardwire
+```
 
-sudo systemctl enable cardwired.service
+Then [enable BPF LSM](#enabling-bpf-lsm) and start the service:
 
-sudo systemctl start cardwired.service
+```bash
+sudo systemctl enable cardwired --now
+```
+
+## Ubuntu
+
+Install build dependencies:
+
+```bash
+sudo apt install clang libbpf-dev linux-headers-$(uname -r)
+```
+
+Install Rust (if not already installed):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Then clone and build:
+
+```bash
+git clone https://github.com/OpenGamingCollective/cardwire.git
+make build
+sudo make install
+```
+
+Then [enable BPF LSM](#enabling-bpf-lsm) and start the service:
+
+```bash
+sudo systemctl enable cardwired --now
+```
+
+## Enabling BPF LSM (with GRUB)
+
+Check your kernel's default LSM list:
+
+On Ubuntu/Fedora:
+```bash
+grep CONFIG_LSM= /boot/config-$(uname -r)
+```
+
+On Arch and other distros:
+```bash
+zcat /proc/config.gz | grep CONFIG_LSM=
+```
+
+> Outputs e.g. `CONFIG_LSM="landlock,lockdown,yama,integrity,apparmor"`
+
+Edit `/etc/default/grub` and append `bpf` to `GRUB_CMDLINE_LINUX_DEFAULT`, keeping all existing entries:
+
+```
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash lsm=landlock,lockdown,yama,integrity,apparmor,bpf"
+```
+
+> [!IMPORTANT]
+> Do not set `lsm=bpf` alone — that drops other active security policies. Always append `bpf` to the existing list from the command above.
+
+Apply and reboot:
+
+| Distro | Command |
+|--------|---------|
+| Ubuntu | `sudo update-grub` |
+| Fedora | `sudo grub2-mkconfig -o /boot/grub2/grub.cfg` |
+| Arch   | `sudo grub-mkconfig -o /boot/grub/grub.cfg` |
+
+```bash
+sudo reboot
 ```
 
 ## Other distros
 
-For now, other distros must clone the repo and use `make` to build and install Cardwire.
+For now, other distros must clone the repo and use `make` to build and install Cardwire. You will also need to enable BPF LSM manually — see the [Enabling BPF LSM](#enabling-bpf-lsm) section above.
 
 Build dependencies:
 
@@ -77,7 +144,7 @@ sudo make install
 > [!CAUTION]
 > Makefile wasn't tested, use with caution.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > For mainstream distros, i will be making an official install methods, like a copr for Fedora and a .deb for Debian based.
 
 ## Non-systemd distros

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -11,16 +11,15 @@ uname -r
 ```
 
 Built with `CONFIG_BPF_LSM` enabled
+
+On e.g. Ubuntu/Fedora:
+```bash
+grep CONFIG_BPF_LSM /boot/config-$(uname -r)
+```
+
+On other distros possibly:
 ```bash
 zcat /proc/config.gz | grep CONFIG_BPF_LSM
 ```
+
 > returns `CONFIG_BPF_LSM=y` if it's enabled
-
-Enabled in the boot cmdline
-```bash
-cat /proc/cmdline
-```
-> Must contains `lsm=bpf` (If empty/doesnt contain bpf, please read Caution)
-
-> [!CAUTION]
-> Most distros already enable bpf, only change the cmdline if cardwired doesnt launch

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -9,55 +9,58 @@ cardwire list
 ```
 
 For each detected GPU, the command will return:
-- An identifier (`ID`). These are used for manual blocking and unblocking. 
+- An identifier (`ID`). These are used for manual blocking and unblocking.
 - The GPU's name (`NAME`)
-- The GPU's PCI address (`PCI`) 
+- The GPU's PCI address (`PCI`)
 - The associated render node (`RENDER`)
-- The associated device node (`CARD`) 
-- Whether the GPU has been identified as the default GPU (`DEFAULT`). Default GPUs will remain available when cardwire is set to integrated.  
-- Whether the GPU is currently blocked (`BLOCKED`) 
+- The associated device node (`CARD`)
+- Whether the GPU has been identified as the default GPU (`DEFAULT`). Default GPUs will remain available when cardwire is set to integrated.
+- Whether the GPU is currently blocked (`BLOCKED`)
 
-## Mode switching 
+## Mode switching
 
-GPU modes can be switched using the `cardwire set` command. 
+GPU modes can be switched using the `cardwire set` command.
 
-To have cardwire block all GPUs except the default GPU, use: 
+To have cardwire block all GPUs except the default GPU, use:
 
 ```
 cardwire set integrated
-``` 
+```
 
-To have cardwire allow access to all GPUs, use 
+> [!NOTE]
+> The block only applies to new file opens. Processes that already have the GPU open (e.g. the compositor) will keep their access until they restart. A session logout/login is required for the GPU to fully power down. Check `cardwire gpu --lsof 1` to verify thre's no process keeping e.g. the dedicated GPU awake.
+
+To have cardwire allow access to all GPUs, use
 
 ```
-cardwire set hybrid 
-``` 
+cardwire set hybrid
+```
 
-## Manual blocking and unblocking 
+## Manual blocking and unblocking
 
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > To prevent system breakage, cardwire will not block default GPUs, even when explicitly instructed to do so.
 
-If more granular control over several GPUs is required, cardwire also allows manually blocking individual GPUs by ID. To do so, it needs to be set to manual mode: 
+If more granular control over several GPUs is required, cardwire also allows manually blocking individual GPUs by ID. To do so, it needs to be set to manual mode:
 
 ```
-cardwire set manual 
-``` 
+cardwire set manual
+```
 
-Once set to manual, GPU states can then be set by ID; to find the correct ID, see [Querying GPUs](#Querying-GPUs). 
+Once set to manual, GPU states can then be set by ID; to find the correct ID, see [Querying GPUs](#Querying-GPUs).
 
-To block the GPU with ID `1`: 
+To block the GPU with ID `1`:
 
 ```
 cardwire gpu 1 --block
 ```
 
-To unblock: 
+To unblock:
 
-``` 
+```
 cardwire gpu 1 --unblock
-``` 
+```
 
 ## Battery Auto Switch Mode
 


### PR DESCRIPTION
First of all thank you for all the effort on this successor to `supergfxctl` which I was using before. The direction of this tool seems much better :clap: I think we just have to get it more accessible which I'm trying to achieve by contributing to the docs. It's the points I stumbeled and spent time on so I try to make it easier for the next user. I tried to get a good coverage for all distros but I could only test on Ubuntu 26.04 (Kernel 7, BPF compiled but disabled by default).