### PR TITLE
fix(daemon): persist battery_auto_switch_mode setting at daemon startup

### DIFF
--- a/crates/cardwire-daemon/src/file/config.rs
+++ b/crates/cardwire-daemon/src/file/config.rs
@@ -86,4 +86,7 @@ impl CardwireConfig {
     pub fn battery_auto_switch(&self) -> bool {
         self.battery_auto_switch
     }
+    pub fn battery_auto_switch_mode(&self) -> Modes {
+        self.battery_auto_switch_mode
+    }
 }

--- a/crates/cardwire-daemon/src/interface/config.rs
+++ b/crates/cardwire-daemon/src/interface/config.rs
@@ -21,12 +21,14 @@ impl ConfigMemory {
         let experimental_nvidia_block =
             Arc::new(AtomicBool::new(user_config.experimental_nvidia_block()));
         let battery_auto_switch = Arc::new(AtomicBool::new(user_config.battery_auto_switch()));
+        let battery_auto_switch_mode =
+            Arc::new(RwLock::new(user_config.battery_auto_switch_mode()));
 
         ConfigMemory {
             auto_apply_gpu_state,
             experimental_nvidia_block,
             battery_auto_switch,
-            battery_auto_switch_mode: Arc::new(RwLock::new(Modes::Smart)),
+            battery_auto_switch_mode,
         }
     }
 }


### PR DESCRIPTION
I noticed that when the daemon restarted it didn't take into account the AC automatic mode value inside the config (`cardwire.toml`) and always used Smart. I looked in the code and found the issue where the battery auto-switch mode was hardcoded instead of getting it from the config. I fixed the issue but noticed too late in discord that you already intended to fix it. Here is what I would have done anyway based on what was already there.