### PR TITLE
Typo in docs near the experimental nvidia block section

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -108,7 +108,7 @@ cardwire gpu 1 --unblock
 > [!TIP]
 > Even though it is experimental, enabling this setting is recommended. It helps prevent unwanted GPU wakeups from Vulkan apps (GTK on gnome) and from tools that use /dev/nvidiactl, such as nvtop
 
-To get if battery auto switch is enabled:
+To get if experimental Nvidia block is enabled:
 
 ```bash
 cardwire config experimental-nvidia-block


### PR DESCRIPTION
My apologies for the minimal pr, I promise I didn't do it just to become a contributor like many people these days. The typo just bothered me.