### PR TITLE
Feat auto save settings

### DIFF
--- a/crates/cardwire-daemon/src/file/config.rs
+++ b/crates/cardwire-daemon/src/file/config.rs
@@ -6,8 +6,7 @@ use crate::{
 use anyhow::Context;
 
 use serde::{Deserialize, Serialize};
-use std::fs;
-use zbus::fdo;
+use std::{fs, io};
 const CONFIG_PATH: &str = "/etc/cardwire";
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -65,17 +64,12 @@ impl CardwireConfig {
         Ok(())
     }
     /// Save the config into cardwire.toml
-    pub async fn save_config(&self) -> fdo::Result<()> {
+    pub async fn save_config(&self) -> io::Result<()> {
         let path = format!("{}/cardwire.toml", CONFIG_PATH);
         match toml::to_string_pretty(&self) {
-            Ok(config_toml) => {
-                if let Err(e) = tokio::fs::write(path, config_toml).await {
-                    return Err(fdo::Error::Failed(e.to_string()));
-                }
-            }
-            Err(e) => return Err(fdo::Error::Failed(e.to_string())),
-        };
-        Ok(())
+            Ok(config_toml) => tokio::fs::write(path, config_toml).await,
+            Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+        }
     }
     pub fn experimental_nvidia_block(&self) -> bool {
         self.experimental_nvidia_block

--- a/crates/cardwire-daemon/src/interface/config.rs
+++ b/crates/cardwire-daemon/src/interface/config.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    Arc, atomic::{AtomicBool, Ordering}
+    Arc, atomic::{AtomicBool, AtomicU32, Ordering}
 };
 
 use crate::{file::CardwireConfig, interface::Modes};
@@ -12,7 +12,7 @@ pub struct ConfigMemory {
     pub auto_apply_gpu_state: Arc<AtomicBool>,
     pub experimental_nvidia_block: Arc<AtomicBool>,
     pub battery_auto_switch: Arc<AtomicBool>,
-    pub battery_auto_switch_mode: Arc<RwLock<Modes>>,
+    pub battery_auto_switch_mode: Arc<AtomicU32>,
 }
 impl ConfigMemory {
     /// build a ConfigMemory from CardwireConfig
@@ -21,9 +21,9 @@ impl ConfigMemory {
         let experimental_nvidia_block =
             Arc::new(AtomicBool::new(user_config.experimental_nvidia_block()));
         let battery_auto_switch = Arc::new(AtomicBool::new(user_config.battery_auto_switch()));
-        let battery_auto_switch_mode =
-            Arc::new(RwLock::new(user_config.battery_auto_switch_mode()));
-
+        let battery_auto_switch_mode = Arc::new(AtomicU32::new(
+            user_config.battery_auto_switch_mode().into(),
+        ));
         ConfigMemory {
             auto_apply_gpu_state,
             experimental_nvidia_block,
@@ -70,8 +70,7 @@ impl ConfigInterface {
     }
     #[zbus(property)]
     pub async fn battery_auto_switch_mode(&self) -> fdo::Result<u32> {
-        let mode_lock = self.config.battery_auto_switch_mode.read().await;
-        let mode = Modes::into(*mode_lock);
+        let mode = self.config.battery_auto_switch_mode.load(Ordering::Relaxed);
         Ok(mode)
     }
 
@@ -100,22 +99,21 @@ impl ConfigInterface {
     }
     #[zbus(property)]
     pub async fn set_battery_auto_switch_mode(&self, mode: u32) -> fdo::Result<()> {
-        let mut mode_lock = self.config.battery_auto_switch_mode.write().await;
-        let new_mode =
-            Modes::try_from(mode).map_err(|err| fdo::Error::InvalidArgs(err.to_string()))?;
-        *mode_lock = new_mode;
+        self.config
+            .battery_auto_switch_mode
+            .store(mode, Ordering::Relaxed);
         Ok(())
     }
     /// Save the daemon's configuration to cardwire.toml
     pub async fn save_to_file(&self) -> fdo::Result<()> {
-        let mode = self.config.battery_auto_switch_mode.read().await;
         let config = CardwireConfig::new(
             self.config.auto_apply_gpu_state.load(Ordering::Relaxed),
             self.config
                 .experimental_nvidia_block
                 .load(Ordering::Relaxed),
             self.config.battery_auto_switch.load(Ordering::Relaxed),
-            *mode,
+            Modes::try_from(self.config.battery_auto_switch_mode.load(Ordering::Relaxed))
+                .map_err(|err| fdo::Error::Failed(err.to_string()))?,
         );
         config.save_config().await?;
         Ok(())

--- a/crates/cardwire-daemon/src/interface/config.rs
+++ b/crates/cardwire-daemon/src/interface/config.rs
@@ -1,9 +1,12 @@
-use std::sync::{
-    Arc, atomic::{AtomicBool, AtomicU32, Ordering}
+use std::{
+    io::ErrorKind, sync::{
+        Arc, atomic::{AtomicBool, AtomicU32, Ordering}
+    }
 };
 
 use crate::{file::CardwireConfig, interface::Modes};
 use cardwire_ebpf::{EbpfBlocker, EbpfSettings};
+use log::warn;
 use tokio::sync::RwLock;
 use zbus::{fdo, interface};
 
@@ -55,18 +58,15 @@ impl ConfigInterface {
         Ok(self.config.auto_apply_gpu_state.load(Ordering::Relaxed))
     }
     #[zbus(property)]
-    pub async fn set_auto_apply_gpu_state(&mut self, state: bool) -> fdo::Result<()> {
-        self.config
-            .auto_apply_gpu_state
-            .store(state, Ordering::Relaxed);
-        Ok(())
-    }
-    #[zbus(property)]
     pub async fn experimental_nvidia_block(&self) -> fdo::Result<bool> {
         Ok(self
             .config
             .experimental_nvidia_block
             .load(Ordering::Relaxed))
+    }
+    #[zbus(property)]
+    pub async fn battery_auto_switch(&self) -> fdo::Result<bool> {
+        Ok(self.config.battery_auto_switch.load(Ordering::Relaxed))
     }
     #[zbus(property)]
     pub async fn battery_auto_switch_mode(&self) -> fdo::Result<u32> {
@@ -76,6 +76,14 @@ impl ConfigInterface {
 
     // setters
     #[zbus(property)]
+    pub async fn set_auto_apply_gpu_state(&mut self, state: bool) -> fdo::Result<()> {
+        self.config
+            .auto_apply_gpu_state
+            .store(state, Ordering::Relaxed);
+        self.save_to_file().await?;
+        Ok(())
+    }
+    #[zbus(property)]
     pub async fn set_experimental_nvidia_block(&mut self, state: bool) -> fdo::Result<()> {
         self.config
             .experimental_nvidia_block
@@ -84,17 +92,17 @@ impl ConfigInterface {
         // change the value in the ebpf map
         blocker
             .set_ebpf_setting(EbpfSettings::ExperimentalNvidia, state.into())
-            .map_err(|e| fdo::Error::Failed(format!("failed to set nvidia block: {}", e)))
+            .map_err(|e| fdo::Error::Failed(format!("failed to set nvidia block: {}", e)))?;
+        self.save_to_file().await?;
+        Ok(())
     }
-    #[zbus(property)]
-    pub async fn battery_auto_switch(&self) -> fdo::Result<bool> {
-        Ok(self.config.battery_auto_switch.load(Ordering::Relaxed))
-    }
+
     #[zbus(property)]
     pub async fn set_battery_auto_switch(&mut self, state: bool) -> fdo::Result<()> {
         self.config
             .battery_auto_switch
             .store(state, Ordering::Relaxed);
+        self.save_to_file().await?;
         Ok(())
     }
     #[zbus(property)]
@@ -102,6 +110,7 @@ impl ConfigInterface {
         self.config
             .battery_auto_switch_mode
             .store(mode, Ordering::Relaxed);
+        self.save_to_file().await?;
         Ok(())
     }
     /// Save the daemon's configuration to cardwire.toml
@@ -115,7 +124,18 @@ impl ConfigInterface {
             Modes::try_from(self.config.battery_auto_switch_mode.load(Ordering::Relaxed))
                 .map_err(|err| fdo::Error::Failed(err.to_string()))?,
         );
-        config.save_config().await?;
-        Ok(())
+        match config.save_config().await {
+            Ok(_) => Ok(()),
+            Err(err) => match err.kind() {
+                ErrorKind::ReadOnlyFilesystem => {
+                    warn!(
+                        "IO Error in save_config: {}, ignoring, system might be nix or bootc",
+                        err
+                    );
+                    Ok(())
+                }
+                _ => Err(fdo::Error::Failed(err.to_string())),
+            },
+        }
     }
 }

--- a/crates/cardwire-daemon/src/tasks/battery_switch.rs
+++ b/crates/cardwire-daemon/src/tasks/battery_switch.rs
@@ -1,13 +1,12 @@
 //! Used to listen to other dbus interface, mainly for auto battery switch and display detection
 
-use std::sync::{Arc, atomic::AtomicBool};
+use std::sync::{
+    Arc, atomic::{AtomicBool, AtomicU32, Ordering}
+};
 
 use log::info;
-use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 use zbus::{Connection, Result, proxy};
-
-use crate::interface::Modes;
 
 #[proxy(
     interface = "org.freedesktop.UPower",
@@ -30,19 +29,13 @@ trait Cardwire {
 
 pub async fn watch_battery_status(
     switch_setting: Arc<AtomicBool>,
-    switch_mode: Arc<RwLock<Modes>>,
+    switch_mode: Arc<AtomicU32>,
 ) -> zbus::Result<()> {
     let connection = Connection::system().await?;
     let upower_proxy = UPowerProxy::new(&connection).await?;
 
     let cardwire = CardwireProxy::new(&connection).await?;
     let mut battery_stream = upower_proxy.receive_on_battery_changed().await;
-    let mode = switch_mode.read().await;
-    info!(
-        "Started listening to on_battery property with mode to set on ac: {}",
-        *mode
-    );
-    drop(mode);
     // only when setting is enabled
     while let Some(msg) = battery_stream.next().await {
         if !switch_setting.load(std::sync::atomic::Ordering::Relaxed) {
@@ -51,16 +44,13 @@ pub async fn watch_battery_status(
         if let Ok(state) = msg.get().await {
             info!("battery event detected: {:?}", state);
             // now get the configured mode and change
-            let mode = switch_mode.read().await;
-            let mode_u32 = Modes::into(*mode);
+            let mode = switch_mode.load(Ordering::Relaxed);
             // ignore dbus api error, it might happen on system with multiple gpus trying to switch
             // to hybrid, the daemon will just refuse
             let _ = match state {
                 true => cardwire.set_mode(0).await,
-                false => cardwire.set_mode(mode_u32).await,
+                false => cardwire.set_mode(mode).await,
             };
-            // just to be sure
-            drop(mode);
         }
     }
 


### PR DESCRIPTION
# Description

Automaticly save new settings to file instead of having to manually save using a dbus API

write error on read-only FS are logged but ignored 

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
