### PR TITLE
feat: Improve sidebar button styling on GUI

### DIFF
--- a/crates/cardwire-gui/src/app.rs
+++ b/crates/cardwire-gui/src/app.rs
@@ -310,7 +310,7 @@ impl AppState {
         }
 
         let final_app = row![
-            container(ui::page_bar())
+            container(ui::page_bar(self.current_tab))
                 .width(Fixed(200.0))
                 .height(Fill)
                 .style(container::rounded_box)

--- a/crates/cardwire-gui/src/ui.rs
+++ b/crates/cardwire-gui/src/ui.rs
@@ -95,14 +95,42 @@ fn link_btn_style(_theme: &iced::Theme, status: button::Status) -> button::Style
     }
 }
 
+fn page_btn_style(
+    theme: &iced::Theme,
+    selected: bool,
+    status: button::Status,
+) -> button::Style {
+    if selected {
+        return button::primary(theme, status);
+    }
+
+    let background = match status {
+        button::Status::Hovered => Color::from_rgb(0.22, 0.22, 0.22),
+        button::Status::Pressed => Color::from_rgb(0.12, 0.12, 0.12),
+        _ => Color::from_rgb(0.16, 0.16, 0.16),
+    };
+
+    button::Style {
+        background: Some(background.into()),
+        text_color: Color::from_rgb(0.95, 0.95, 0.95),
+        border: Border {
+            radius: 4.0.into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
 // Iter over the Page enum and make a button for each variants, Used to navigate around the GUI
-pub fn page_bar() -> Element<'static, Message> {
+pub fn page_bar(current_page: Page) -> Element<'static, Message> {
     let buttons = Page::iter().fold(column![].spacing(10), |col, page| {
+        let selected = page == current_page;
         col.push(
             button(text!("{}", page))
                 .on_press(Message::SwitchPage(page))
                 .width(Fill)
-                .padding([8, 12]),
+                .padding([8, 12])
+                .style(move |theme, status| page_btn_style(theme, selected, status)),
         )
     });
     buttons.into()

--- a/crates/cardwire-gui/src/ui.rs
+++ b/crates/cardwire-gui/src/ui.rs
@@ -95,11 +95,7 @@ fn link_btn_style(_theme: &iced::Theme, status: button::Status) -> button::Style
     }
 }
 
-fn page_btn_style(
-    theme: &iced::Theme,
-    selected: bool,
-    status: button::Status,
-) -> button::Style {
+fn page_btn_style(theme: &iced::Theme, selected: bool, status: button::Status) -> button::Style {
     if selected {
         return button::primary(theme, status);
     }

--- a/crates/cardwire-gui/src/ui.rs
+++ b/crates/cardwire-gui/src/ui.rs
@@ -95,6 +95,7 @@ fn link_btn_style(_theme: &iced::Theme, status: button::Status) -> button::Style
     }
 }
 
+// Styling used for buttons in sidebar
 fn page_btn_style(theme: &iced::Theme, selected: bool, status: button::Status) -> button::Style {
     if selected {
         return button::primary(theme, status);


### PR DESCRIPTION
# Description

<img width="1705" height="1221" alt="image" src="https://github.com/user-attachments/assets/dfb199b4-b63f-40f0-b822-46d805419293" />

Darken unselected GUI sidebar entries and visually identify the current page with Iced's default primary-blue button style.

This change passes the current page into the sidebar renderer, applies neutral dark-gray styling to inactive entries, and retains the familiar default blue only for the selected entry.

Related issue: None.

# TODO

N/A

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
