### PR TITLE
fix: block NVIDIA HDA audio ALSA devices to prevent GPU wakeups

### DIFF
--- a/crates/cardwire-daemon/src/core/inode.rs
+++ b/crates/cardwire-daemon/src/core/inode.rs
@@ -155,6 +155,103 @@ pub fn exp_nvidia_inodes() -> Result<Vec<u64>> {
     Ok(inodes)
 }
 
+/// Find the ALSA device inodes (`/dev/snd/*`) that belong to the NVIDIA HDA
+/// audio controller sibling of the given GPU.
+///
+/// NVIDIA GPUs are multi-function PCI devices: function 0 is the VGA
+/// controller and function 1 is the HDA audio controller. Both functions share
+/// the same PCI power domain, so when a sound server (pipewire or pulseaudio)
+/// opens an ALSA device belonging to the HDA function, the GPU is woken up
+/// from D3cold.
+///
+/// `gpu_pci` is the VGA function address (e.g. `0000:64:00.0`); the HDA
+/// sibling is derived as function 1 (`0000:64:00.1`).
+///
+/// In `/sys/class/sound` only the `cardN` entry has a `device` symlink that
+/// resolves directly to the PCI address. Sub-devices (`controlC{N}`,
+/// `pcmC{N}D{x}p`, `hwC{N}D{x}`) have a `device` symlink that points back at
+/// the `cardN` sysfs dir, not the PCI device. So the matching is done in two
+/// steps:
+///
+/// 1. Find the `cardN` whose `device` symlink resolves to `hda_pci` and remember `N` (the ALSA card
+///    number).
+/// 2. Collect the inode of every `/dev/snd/*` node that belongs to that card (i.e. whose name
+///    contains `C{N}`).
+pub fn nvidia_hda_snd_inodes(gpu_pci: &str) -> Result<Vec<u64>> {
+    // The HDA audio controller is function 1 of the same PCI device.
+    let hda_pci = gpu_pci.replace(".0", ".1");
+
+    let snd_class = Path::new("/sys/class/sound");
+    let dev_snd = Path::new("/dev/snd");
+
+    // Step 1: find the ALSA card number whose "device" symlink resolves to
+    // the HDA PCI address.  Only cardN entries have a direct device → PCI
+    // symlink; control/pcm/hw sub-devices point back at cardN.
+    let entries = fs::read_dir(snd_class)?;
+    let mut card_num: Option<u32> = None;
+    for entry in entries.flatten() {
+        let name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        if !name.starts_with("card") {
+            continue;
+        }
+        let device_link = entry.path().join("device");
+        let device_target = match fs::canonicalize(&device_link) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let pci_address = match device_target.file_name().and_then(|n| n.to_str()) {
+            Some(addr) => addr,
+            None => continue,
+        };
+        if pci_address == hda_pci {
+            if let Some(rest) = name.strip_prefix("card") {
+                card_num = rest.parse::<u32>().ok();
+            }
+            break;
+        }
+    }
+
+    let Some(card_num) = card_num else {
+        // No ALSA card found for the HDA sibling — either the GPU is a
+        // single-function device with no audio, or the HDA controller has no
+        // bound driver. Nothing to block.
+        return Ok(Vec::new());
+    };
+
+    // Step 2: collect the inode of every /dev/snd/* node that belongs to this
+    // card. ALSA device nodes are named `<type>C<card>[D<dev>...]`, e.g.
+    // controlC0, pcmC0D3p, hwC0D0. The static `seq` and `timer` nodes have no
+    // card number and are skipped. We match on `C{card}` followed by either the
+    // end of the name or a `D` so that card 0 doesn't accidentally match card
+    // 10+.
+    let card_marker = format!("C{}", card_num);
+    let mut inodes: Vec<u64> = Vec::new();
+    for entry in fs::read_dir(dev_snd)?.flatten() {
+        let name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        // Find the card marker and verify the char after it is 'D' or EOL.
+        let Some(pos) = name.find(&card_marker) else {
+            continue;
+        };
+        let after = &name[pos + card_marker.len()..];
+        if !after.is_empty() && !after.starts_with('D') {
+            continue;
+        }
+
+        let dev_path = dev_snd.join(&name);
+        if let Ok(metadata) = fs::metadata(&dev_path) {
+            inodes.push(metadata.ino());
+        }
+    }
+
+    Ok(inodes)
+}
+
 pub fn sys_drm_inodes(render: u32, card: u32) -> Result<Vec<u64>> {
     let mut inodes = Vec::new();
     let sys_path = Path::new("/sys/class/drm");

--- a/crates/cardwire-daemon/src/interface/gpu.rs
+++ b/crates/cardwire-daemon/src/interface/gpu.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     core::{
         gpu::{DbusGpuDevice, GpuDevice, GpuVendor}, inode::{
-            backlight_to_inode, card_to_inode, nvidia_to_inode, pci_to_inode, render_to_inode, single_pci_to_inode, sys_drm_inodes
+            backlight_to_inode, card_to_inode, nvidia_hda_snd_inodes, nvidia_to_inode, pci_to_inode, render_to_inode, single_pci_to_inode, sys_drm_inodes
         }, pci::PciDevice
     }, file::{CardwireGpuState, CardwireModeState}, interface::Modes
 };
@@ -135,6 +135,25 @@ impl GpuInterface {
                     );
                 }
             };
+            // Block the ALSA device files of the NVIDIA HDA audio controller.
+            // The HDA function (function 1) shares the GPU's PCI power domain,
+            // so sound-server probes of /dev/snd/* wake the GPU from D3cold.
+            match nvidia_hda_snd_inodes(self.device.pci.pci_address()) {
+                Ok(inodes) => {
+                    for inode in inodes {
+                        if let Err(err) = blocker.block_inode(inode) {
+                            error!("failed to block nvidia HDA snd inode {}: {}", inode, err);
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!(
+                        "(ignoring) failed to find nvidia HDA snd inodes for {}: {}",
+                        self.device.pci.pci_address(),
+                        err
+                    );
+                }
+            };
         }
         Ok(())
     }
@@ -180,6 +199,23 @@ impl GpuInterface {
                     warn!(
                         "(ignoring) failed to unblock backlight nvidia_{}: {}",
                         minor, err
+                    );
+                }
+            };
+            // Unblock the ALSA device files of the NVIDIA HDA audio controller.
+            match nvidia_hda_snd_inodes(self.device.pci.pci_address()) {
+                Ok(inodes) => {
+                    for inode in inodes {
+                        if let Err(err) = blocker.unblock_inode(inode) {
+                            warn!("failed to unblock nvidia HDA snd inode {}: {}", inode, err);
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        "(ignoring) failed to find nvidia HDA snd inodes for {}: {}",
+                        self.device.pci.pci_address(),
+                        err
                     );
                 }
             };

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -46,6 +46,9 @@ cardwire set integrated
 > [!TIP]
 > The dedicated GPU can still power down even if your desktop has it open, as long as nothing is actively using it. To double-check, run: `cardwire gpu 1 --lsof`
 
+> [!NOTE]
+> For NVIDIA GPUs, cardwire also blocks the ALSA device files (`/dev/snd/*`) belonging to the GPU's HDA audio controller. NVIDIA GPUs are multi-function PCI devices: function 0 is the VGA controller and function 1 is the HDA audio controller, and both share the same PCI power domain. Without blocking the ALSA devices, sound servers (pipewire or pulseaudio) periodically probe them and wake the GPU from D3cold.
+
 ### Hybrid
 
 To have cardwire allow access to all GPUs, use


### PR DESCRIPTION
## Summary

The NVIDIA GPU block was not preventing GPU wake-ups caused by the NVIDIA HDA audio controller. When the GPU is in D3cold and a sound server (pipewire/pulseaudio) periodically probes the ALSA devices belonging to the HDA function, the GPU wakes up because both PCI functions share the same power domain.

### Root cause

NVIDIA GPUs are multi-function PCI devices:
- Function 0 (`0000:64:00.0`): VGA controller (class `0x0300`)
- Function 1 (`0000:64:00.1`): HDA audio controller (class `0x0403`)
- Function 2: USB xHCI host controller (only on some GPUs, e.g. TU106)
- Function 3: USB Type-C UCSI controller (only on some GPUs)

`read_gpu()` only collects devices with class `0x03` (display controllers), so the HDA audio function is never registered as a GPU device. The existing `pci_to_inode()` does try to block the `.1` PCI sysfs directory via the `.0` → `.1` string replacement, but sound servers don't touch sysfs — they open the character devices under `/dev/snd/` (e.g. `controlC0`, `pcmC0D3p`, `hwC0D0`). Those inodes were never added to the block list, so the eBPF `file_open`/`inode_permission` hooks let the `open()` through, the HDA controller transitions to D0, and since it shares the power domain with the VGA function the whole GPU wakes up.

### NVIDIA PCI function numbering (hardware convention)

The function numbers are a hardware convention, not random:

| Function | Device type | Present on |
|----------|-------------|------------|
| 0 | VGA / 3D controller | Always |
| 1 | HDA audio controller | Multi-function GPUs only |
| 2 | USB xHCI host controller | Some (e.g. TU106 RTX 2060/2070) |
| 3 | USB Type-C UCSI controller | Some |

This is confirmed by NVIDIA's own [RTD3 power management documentation](https://download.nvidia.com/XFree86/Linux-x86_64/435.17/README/dynamicpowermanagement.html), which explicitly lists removing *"Audio device PCI function, USB xHCI Host Controller function as well as USB Type-C UCSI Controller PCI function"* — and by real-world `lspci` output across many GPU generations:

```
01:00.0 VGA compatible controller [0300]: NVIDIA Corporation ... [10de:1f15]
01:00.1 Audio device [0403]:                NVIDIA Corporation ... [10de:10f9]
01:00.2 USB controller [0c03]:              NVIDIA Corporation ... [10de:1ada]
01:00.3 Serial controller [0700]:           NVIDIA Corporation ... [10de:1adb]
```

The PCI bus/device numbers (e.g. `64:00`, `01:00`) vary per machine depending on motherboard PCIe topology, but the **function numbers** are fixed. Function 1 is always the HDA audio controller when the GPU is a multi-function device. Deriving the HDA sibling via `.replace(".0", ".1")` is the correct and robust approach — and is already what the existing `pci_to_inode()` does for the sysfs path. If the GPU is a single-function device with no audio function, `0000:64:00.1` simply doesn't exist and the function returns an empty list.

### ALSA sysfs layout (important for the matching logic)

In `/sys/class/sound`, only the `cardN` entry has a `device` symlink that resolves directly to the PCI address. Sub-devices (`controlC{N}`, `pcmC{N}D{x}p`, `hwC{N}D{x}`) have a `device` symlink that points back at the `cardN` sysfs dir, **not** the PCI device. Example from the bug reporter's machine:

```
$ ls /dev/snd/by-path/
pci-0000:64:00.1 -> ../controlC0   ← NVIDIA HDA (card 0)
pci-0000:65:00.1 -> ../controlC1   ← AMD iGPU audio (card 1)
pci-0000:65:00.6 -> ../controlC2   ← Realtek audio (card 2)
```

So the matching is done in two steps:
1. Find the `cardN` whose `device` symlink resolves to the HDA PCI address (`0000:64:00.1`), and remember `N` (the ALSA card number).
2. Collect the inode of every `/dev/snd/*` node that belongs to that card (matching `C{N}` followed by `D` or end-of-name, to avoid card 0 matching card 10+).

For the bug reporter's system, this correctly blocks exactly: `controlC0`, `hwC0D0`, `pcmC0D3p`, `pcmC0D7p`, `pcmC0D8p`, `pcmC0D9p` — and skips the AMD/Realtek cards 1 and 2.

### Fix

Added `nvidia_hda_snd_inodes()` in `inode.rs` — takes the GPU's VGA PCI address, derives the HDA sibling as function 1, scans `/sys/class/sound` for the `cardN` whose `device` symlink resolves to the HDA PCI address, then collects the inodes of all `/dev/snd/*` nodes belonging to that card. These inodes are blocked/unblocked alongside the existing `nvidia_to_inode` and `backlight_to_inode` calls in `block_gpu()`/`unblock_gpu()`, so the fix applies in every mode (integrated, manual, smart) without requiring the experimental nvidia block flag.

This is not a flag-gated experiment — it's a straightforward fix to the per-GPU block path. The HDA inodes are now treated like the `/dev/nvidia0` and backlight inodes: part of the standard NVIDIA block.

## Test Plan

- [ ] `cargo build` / `nix flake check` passes
- [ ] `cardwire set integrated` blocks the NVIDIA GPU; `cardwire list --json` shows `blocked: true`
- [ ] Monitor `/sys/bus/pci/devices/0000:64:00.0/power_state` — GPU stays in `D3cold` even when pipewire/pulseaudio runs
- [ ] `dmesg` no longer repeats `nvidia 0000:64:00.0: Enabling HDA controller`
- [ ] Audio output that does **not** route through the NVIDIA HDMI (e.g. laptop speakers, headset) still works
- [ ] `cardwire set hybrid` unblocks the GPU and the HDA ALSA devices are accessible again

## Checklist

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang) — needs CI
- [ ] New and existing unit tests pass locally with my changes — needs CI
