### PR TITLE
refactor(cardwired): replace mpsc channels with a task::spawn

### DIFF
--- a/crates/cardwire-daemon/src/analyzer/models.rs
+++ b/crates/cardwire-daemon/src/analyzer/models.rs
@@ -3,7 +3,7 @@ use cardwire_ebpf::EbpfBlocker;
 use log::{debug, info, warn};
 use std::{collections::HashMap, fs, path::PathBuf, ptr, sync::Arc};
 use tokio::{
-    io::{Interest, unix::AsyncFd}, sync::{Mutex, RwLock, mpsc}, time::Instant
+    io::{Interest, unix::AsyncFd}, sync::{Mutex, RwLock}, task, time::Instant
 };
 
 use crate::analyzer::{
@@ -21,11 +21,6 @@ pub struct Event {
 #[derive(Debug, Copy, Clone)]
 pub struct Close {
     pub pid: u32,
-}
-
-pub enum EventMsg {
-    Exec(Event),
-    Close(Close),
 }
 
 #[derive(Clone)]
@@ -64,135 +59,83 @@ impl CardwireAnalyzer {
         })
     }
     pub async fn run(self) -> anyhow::Result<()> {
-        // Create the channel
-        let (tx, mut rx) = mpsc::channel::<EventMsg>(10_000);
-
         // Clone the Arcs and Sender to move into the background task
         let exec_arc = self.exec_ring.clone();
         let close_arc = self.close_ring.clone();
-        let tx_task = tx.clone();
-
-        tokio::spawn(async move {
-            // Lock the buffers once
-            let mut exec_ring = exec_arc.lock().await;
-            let mut close_ring = close_arc.lock().await;
-
-            loop {
-                tokio::select! {
-                    Ok(mut guard) = exec_ring.ready_mut(Interest::READABLE) => {
-                        if guard.ready().is_readable() {
-                            while let Some(item) = guard.get_inner_mut().next() {
-                                if item.len() < std::mem::size_of::<Event>() {
-                                    debug!("Skipping malformed exec event. Size: {}", item.len());
-                                    continue;
-                                }
-                                let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Event) };
-                                let _ = tx_task.try_send(EventMsg::Exec(event));
+        // Lock the buffers once
+        let mut exec_ring = exec_arc.lock().await;
+        let mut close_ring = close_arc.lock().await;
+        let shared_self = Arc::new(self);
+        loop {
+            tokio::select! {
+                Ok(mut guard) = exec_ring.ready_mut(Interest::READABLE) => {
+                    if guard.ready().is_readable() {
+                        while let Some(item) = guard.get_inner_mut().next() {
+                            if item.len() < std::mem::size_of::<Event>() {
+                                debug!("Skipping malformed exec event. Size: {}", item.len());
+                                continue;
                             }
-                            guard.clear_ready();
+                            let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Event) };
+                            let this = Arc::clone(&shared_self);
+                            task::spawn(async move {
+                                this.spawn_open_analyzer(event).await
+                            });
                         }
+                        guard.clear_ready();
                     }
+                }
 
-                    Ok(mut guard) = close_ring.ready_mut(Interest::READABLE) => {
-                        if guard.ready().is_readable() {
-                            while let Some(item) = guard.get_inner_mut().next() {
-                                if item.len() < std::mem::size_of::<Close>() {
-                                    debug!("Skipping malformed close event. Size: {}", item.len());
-                                    continue;
-                                }
-                                let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Close) };
-                                let _ = tx_task.try_send(EventMsg::Close(event));
+                Ok(mut guard) = close_ring.ready_mut(Interest::READABLE) => {
+                    if guard.ready().is_readable() {
+                        while let Some(item) = guard.get_inner_mut().next() {
+                            if item.len() < std::mem::size_of::<Close>() {
+                                debug!("Skipping malformed close event. Size: {}", item.len());
+                                continue;
                             }
-                            guard.clear_ready();
+                            let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Close) };
+                                                        let this = Arc::clone(&shared_self);
+                            task::spawn(async move {
+                                this.spawn_remove_analyzer(event).await
+                            });
                         }
+                        guard.clear_ready();
                     }
-                }
-            } // end loop
-        });
-
-        // Garbage collector to not overflow the map and to keep it clean
-        let gc_map = self.pid_map.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                debug!("Running Garbage Collector...");
-                let keys: Vec<u32> = {
-                    let map = gc_map.read().await;
-                    map.keys().flatten().collect()
-                };
-                let mut dead_pids: Vec<u32> = Vec::new();
-                for pid in keys {
-                    let proc_path = format!("/proc/{}", pid);
-                    if tokio::fs::metadata(&proc_path).await.is_err() {
-                        dead_pids.push(pid);
-                    }
-                }
-                if !dead_pids.is_empty() {
-                    let mut map = gc_map.write().await;
-                    let dead_pids_len = dead_pids.len();
-                    for pid in dead_pids {
-                        let _ = map.remove(&pid);
-                    }
-                    debug!("Garbage Collector removed {} pids", dead_pids_len);
-                } else {
-                    debug!("Garbage Collector found 0 ghost pids");
-                }
-            }
-        });
-
-        while let Some(msg) = rx.recv().await {
-            match msg {
-                EventMsg::Exec(event) => {
-                    let self_clone = self.clone();
-                    tokio::spawn(async move {
-                        let time = Instant::now();
-                        let pid_map = self_clone.pid_map.read().await;
-                        if pid_map.get(&event.pid, 0).is_ok() {
-                            return;
-                        }
-                        drop(pid_map);
-                        let real_app_name = match get_real_process_name(event.pid) {
-                            Some(name) => name,
-                            None => return,
-                        };
-                        if let Some(result) =
-                            self_clone.evaluate_app(event.pid, &real_app_name).await
-                            && result
-                        {
-                            info!(
-                                "ALLOW: pid: {} process: {} in {}us",
-                                event.pid,
-                                &real_app_name,
-                                time.elapsed().as_micros()
-                            );
-                            let mut pid_map = self_clone.pid_map.write().await;
-                            if let Err(e) = pid_map.insert(event.pid, 1, 0) {
-                                warn!("Failed to insert into eBPF map: {}", e);
-                            }
-                        }
-                    });
-                }
-                // On close event, remove from map, i made a garbage collector just in case a pid
-                // didn't get removed
-                EventMsg::Close(event) => {
-                    let self_clone = self.clone();
-                    tokio::spawn(async move {
-                        let real_app_name = match get_real_process_name(event.pid) {
-                            Some(name) => name,
-                            None => "unknown".to_string(),
-                        };
-                        let mut pid_map = self_clone.pid_map.write().await;
-                        // we keep java in the map, and let the garbage collector take care of it,
-                        // this fix minecraft not using the dgpu
-                        if !real_app_name.contains("java") && pid_map.remove(&event.pid).is_ok() {
-                            debug!("REMOVE: pid: {}", event.pid);
-                        }
-                    });
                 }
             }
         }
+    }
 
-        Ok(())
+    async fn spawn_open_analyzer(&self, event: Event) -> () {
+        let time = Instant::now();
+        let pid_map = self.pid_map.read().await;
+        if pid_map.get(&event.pid, 0).is_ok() {
+            return;
+        }
+        drop(pid_map);
+        let real_app_name = match get_real_process_name(event.pid) {
+            Some(name) => name,
+            None => return,
+        };
+        if let Some(result) = self.evaluate_app(event.pid, &real_app_name).await
+            && result
+        {
+            info!(
+                "ALLOW: pid: {} process: {} in {}us",
+                event.pid,
+                &real_app_name,
+                time.elapsed().as_micros()
+            );
+            let mut pid_map = self.pid_map.write().await;
+            if let Err(e) = pid_map.insert(event.pid, 1, 0) {
+                warn!("Failed to insert into eBPF map: {}", e);
+            }
+        }
+    }
+    async fn spawn_remove_analyzer(&self, event: Close) -> () {
+        let mut pid_map = self.pid_map.write().await;
+        if pid_map.remove(&event.pid).is_ok() {
+            debug!("REMOVE: pid: {}", event.pid);
+        }
     }
 
     /// Default app are blocked, try to find if it's a game or a gpu intensive app

--- a/crates/cardwire-daemon/src/analyzer/models.rs
+++ b/crates/cardwire-daemon/src/analyzer/models.rs
@@ -93,7 +93,7 @@ impl CardwireAnalyzer {
                                 continue;
                             }
                             let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Close) };
-                                                        let this = Arc::clone(&shared_self);
+                            let this = Arc::clone(&shared_self);
                             task::spawn(async move {
                                 this.spawn_remove_analyzer(event).await
                             });


### PR DESCRIPTION
# Description

Reaplce mspc channels in cardwire analyzer with a direct task::spawn and asyncmove

Fixes # (issue)

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
