### PR TITLE
feat: add tests for all crates

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -82,6 +82,8 @@ jobs:
     if: needs.prepare.outputs.run_rust_checks == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y clang libbpf-dev libudev-dev pkg-config gcc-multilib
       - uses: dtolnay/rust-toolchain@eac0f66a48bc4b70a10b9acd4c4e930f835d95ff
       - name: Test code
         run: cargo test --all

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,7 +78,6 @@ jobs:
     needs: [prepare]
     permissions:
       contents: read
-      pull-requests: write
     if: needs.prepare.outputs.run_rust_checks == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           components: rustfmt
       - name: Format code
-        run: cargo +nightly fmt
+        run: cargo +nightly fmt --all --check
       - name: Suggest formatting changes
         uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46 # v1.24.3
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,12 +1,9 @@
 name: CICD
-
 on:
   pull_request:
-
 permissions:
   contents: read
   pull-requests: read
-
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -76,7 +73,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           check-args: --locked --all-targets --all-features
           args: -D warnings
-
+  rust-test:
+    name: Rust Test
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    permissions:
+      contents: read
+      pull-requests: write
+    if: needs.prepare.outputs.run_rust_checks == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@eac0f66a48bc4b70a10b9acd4c4e930f835d95ff
+        with:
+          toolchain: 1.95.0
+      - name: Test code
+        run: cargo test --all
   rust-format:
     name: Rust Format
     runs-on: ubuntu-latest
@@ -97,7 +108,6 @@ jobs:
         uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46 # v1.24.3
         with:
           tool_name: rustfmt
-
   c-format:
     name: C Format
     runs-on: ubuntu-latest
@@ -108,7 +118,6 @@ jobs:
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format
       - run: clang-format --dry-run --Werror -i ./crates/cardwire-ebpf/src/bpf.c
-
   vm-test:
     runs-on: ubuntu-latest
     needs: [prepare, rust-lint, rust-format, c-format]
@@ -117,7 +126,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: determinateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - run: nix build .#vm-test
-  
   mdbook-test:
     runs-on: ubuntu-latest
     needs: [prepare]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,7 +66,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang libbpf-dev libudev-dev pkg-config gcc-multilib
       - uses: dtolnay/rust-toolchain@eac0f66a48bc4b70a10b9acd4c4e930f835d95ff # 1.95.0
         with:
-          toolchain: 1.95.0
           components: clippy
       - uses: auguwu/clippy-action@9817d076b82df0194935be9db6154c56ac07b317 # 1.5.0
         with:
@@ -84,8 +83,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@eac0f66a48bc4b70a10b9acd4c4e930f835d95ff
-        with:
-          toolchain: 1.95.0
       - name: Test code
         run: cargo test --all
   rust-format:
@@ -100,7 +97,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@nightly # Nightly
         with:
-          toolchain: nightly
           components: rustfmt
       - name: Format code
         run: cargo +nightly fmt

--- a/crates/cardwire-cli/src/args.rs
+++ b/crates/cardwire-cli/src/args.rs
@@ -142,3 +142,123 @@ pub struct GpuAction {
     #[arg(long, help = "Get GPU power state")]
     pub power: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli_mode_display_all_variants() {
+        assert_eq!(CliMode::Integrated.to_string(), "Integrated");
+        assert_eq!(CliMode::Hybrid.to_string(), "Hybrid");
+        assert_eq!(CliMode::Manual.to_string(), "Manual");
+        assert_eq!(CliMode::Smart.to_string(), "Smart");
+    }
+
+    #[test]
+    fn test_args_parse_set_command() {
+        let args = Args::try_parse_from(["cardwire", "set", "hybrid"]).unwrap();
+        match args.command {
+            Commands::Set { mode } => assert!(matches!(mode, CliMode::Hybrid)),
+            _ => panic!("expected Set command"),
+        }
+    }
+
+    #[test]
+    fn test_args_parse_get_command() {
+        let args = Args::try_parse_from(["cardwire", "get"]).unwrap();
+        assert!(matches!(args.command, Commands::Get));
+    }
+
+    #[test]
+    fn test_args_parse_list_command() {
+        let args = Args::try_parse_from(["cardwire", "list"]).unwrap();
+        match args.command {
+            Commands::List { full, json } => {
+                assert!(!full);
+                assert!(!json);
+            }
+            _ => panic!("expected List command"),
+        }
+    }
+
+    #[test]
+    fn test_args_parse_list_with_json_flag() {
+        let args = Args::try_parse_from(["cardwire", "list", "--json"]).unwrap();
+        match args.command {
+            Commands::List { json, .. } => assert!(json),
+            _ => panic!("expected List command"),
+        }
+    }
+
+    #[test]
+    fn test_args_parse_list_with_full_flag() {
+        let args = Args::try_parse_from(["cardwire", "list", "--full"]).unwrap();
+        match args.command {
+            Commands::List { full, .. } => assert!(full),
+            _ => panic!("expected List command"),
+        }
+    }
+
+    #[test]
+    fn test_args_parse_gpu_block_command() {
+        let args = Args::try_parse_from(["cardwire", "gpu", "1", "--block"]).unwrap();
+        match args.command {
+            Commands::Gpu { id, action } => {
+                assert_eq!(id, 1);
+                assert!(action.block);
+                assert!(!action.unblock);
+            }
+            _ => panic!("expected Gpu command"),
+        }
+    }
+
+    #[test]
+    fn test_args_parse_set_all_modes() {
+        for mode_str in ["integrated", "hybrid", "manual", "smart"] {
+            let result = Args::try_parse_from(["cardwire", "set", mode_str]);
+            assert!(result.is_ok(), "failed to parse mode: {mode_str}");
+        }
+    }
+
+    #[test]
+    fn test_args_parse_set_invalid_mode_fails() {
+        let result = Args::try_parse_from(["cardwire", "set", "asusmux"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_args_parse_config_auto_apply() {
+        let args =
+            Args::try_parse_from(["cardwire", "config", "auto-apply-gpu-state", "true"]).unwrap();
+        match args.command {
+            Commands::Config { action } => match action {
+                ConfigAction::AutoApplyGpuState { set } => assert_eq!(set, Some(true)),
+                _ => panic!("expected AutoApplyGpuState"),
+            },
+            _ => panic!("expected Config command"),
+        }
+    }
+
+    #[test]
+    fn test_args_parse_manager_status() {
+        let args = Args::try_parse_from(["cardwire", "manager", "status"]).unwrap();
+        assert!(matches!(
+            args.command,
+            Commands::Manager {
+                action: ManagerAction::Status
+            }
+        ));
+    }
+
+    #[test]
+    fn test_args_parse_debug_diagnostic() {
+        let args = Args::try_parse_from(["cardwire", "debug", "diagnostic-gpu"]).unwrap();
+        assert!(matches!(
+            args.command,
+            Commands::Debug {
+                action: DebugAction::DiagnosticGpu
+            }
+        ));
+    }
+}

--- a/crates/cardwire-cli/src/display.rs
+++ b/crates/cardwire-cli/src/display.rs
@@ -151,7 +151,7 @@ mod tests {
         let parsed: BTreeMap<usize, GpuDevice> = serde_json::from_str(&json_str).unwrap();
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[&0].name, "Intel UHD");
-        assert_eq!(parsed[&1].blocked, true);
+        assert!(parsed[&1].blocked);
     }
 
     #[test]

--- a/crates/cardwire-cli/src/display.rs
+++ b/crates/cardwire-cli/src/display.rs
@@ -120,3 +120,59 @@ fn pretty_print_gpu(gpu_list: BTreeMap<usize, GpuDevice>) {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn make_gpu(id: u32, name: &str, pci: &str, default: bool, blocked: bool) -> GpuDevice {
+        GpuDevice {
+            id,
+            name: name.to_string(),
+            pci: pci.to_string(),
+            render: 128,
+            card: 0,
+            default,
+            blocked,
+            nvidia: false,
+            nvidia_minor: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_print_devices_json_produces_valid_json() {
+        let mut map = BTreeMap::new();
+        map.insert(0, make_gpu(0, "Intel UHD", "0000:00:02.0", true, false));
+        map.insert(1, make_gpu(1, "RTX 4060", "0000:01:00.0", false, true));
+
+        let json_str = serde_json::to_string_pretty(&map).unwrap();
+        // Verify it parses back
+        let parsed: BTreeMap<usize, GpuDevice> = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[&0].name, "Intel UHD");
+        assert_eq!(parsed[&1].blocked, true);
+    }
+
+    #[test]
+    fn test_print_devices_json_empty_map() {
+        let map: BTreeMap<usize, GpuDevice> = BTreeMap::new();
+        let json_str = serde_json::to_string_pretty(&map).unwrap();
+        assert_eq!(json_str, "{}");
+    }
+
+    #[test]
+    fn test_gpu_device_fields_roundtrip_through_serde() {
+        let gpu = make_gpu(42, "RX 7900 XTX", "0000:03:00.0", false, false);
+        let json = serde_json::to_string(&gpu).unwrap();
+        let parsed: GpuDevice = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, 42);
+        assert_eq!(parsed.name, "RX 7900 XTX");
+        assert_eq!(parsed.pci, "0000:03:00.0");
+        assert_eq!(parsed.render, 128);
+        assert_eq!(parsed.card, 0);
+        assert!(!parsed.default);
+        assert!(!parsed.blocked);
+        assert!(!parsed.nvidia);
+    }
+}

--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -81,3 +81,224 @@ pub fn check_gpu_env(environ: &[u8]) -> bool {
     // Not present
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /*
+        check_steam_environ
+    */
+    #[test]
+    fn test_check_steam_environ_detects_steam_app_id() {
+        let environ = b"HOME=/home/user\0SteamAppId=12345\0DISPLAY=:0";
+        assert!(check_steam_environ(environ));
+    }
+
+    #[test]
+    fn test_check_steam_environ_returns_false_when_absent() {
+        let environ = b"HOME=/home/user\0DISPLAY=:0\0TERM=xterm";
+        assert!(!check_steam_environ(environ));
+    }
+
+    #[test]
+    fn test_check_steam_environ_returns_false_for_empty_input() {
+        assert!(!check_steam_environ(b""));
+    }
+
+    #[test]
+    fn test_check_steam_environ_detects_at_start_of_environ() {
+        let environ = b"SteamAppId=999";
+        assert!(check_steam_environ(environ));
+    }
+
+    /*
+        check_gamemode
+    */
+
+    #[test]
+    fn test_check_gamemode_detects_library_in_maps() {
+        let map = b"/usr/lib/libgamemodeauto.so\n/usr/lib/libc.so";
+        assert!(check_gamemode(map));
+    }
+
+    #[test]
+    fn test_check_gamemode_returns_false_when_absent() {
+        let map = b"/usr/lib/libc.so.6\n/usr/lib/libm.so.6";
+        assert!(!check_gamemode(map));
+    }
+
+    #[test]
+    fn test_check_gamemode_returns_false_for_empty_input() {
+        assert!(!check_gamemode(b""));
+    }
+
+    #[test]
+    fn test_check_gamemode_rejects_partial_library_name() {
+        let map = b"libgamemodeaut.so";
+        assert!(!check_gamemode(map));
+    }
+
+    /*
+        check_fdo_app_id
+    */
+
+    #[test]
+    fn test_check_fdo_app_id_found_in_list() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("steam".to_string(), true);
+        xdg_list.insert("lutris".to_string(), true);
+        assert!(check_fdo_app_id("steam", &xdg_list));
+    }
+
+    #[test]
+    fn test_check_fdo_app_id_not_found_in_list() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("steam".to_string(), true);
+        assert!(!check_fdo_app_id("firefox", &xdg_list));
+    }
+
+    #[test]
+    fn test_check_fdo_app_id_empty_map_returns_false() {
+        let xdg_list = HashMap::new();
+        assert!(!check_fdo_app_id("anything", &xdg_list));
+    }
+
+    #[test]
+    fn test_check_fdo_app_id_is_case_sensitive() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("Steam".to_string(), true);
+        assert!(!check_fdo_app_id("steam", &xdg_list));
+        assert!(check_fdo_app_id("Steam", &xdg_list));
+    }
+
+    /*
+        check_for_flatpak_run
+    */
+    #[test]
+    fn test_check_for_flatpak_run_detects_flatpak_binary() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("com.valvesoftware.Steam".to_string(), true);
+        let cmdline = "/usr/bin/flatpak\0run\0com.valvesoftware.Steam";
+        assert!(check_for_flatpak_run(cmdline, &xdg_list));
+    }
+
+    #[test]
+    fn test_check_for_flatpak_run_detects_bwrap_binary() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("com.valvesoftware.Steam".to_string(), true);
+        let cmdline = "/usr/bin/bwrap\0--arg\0com.valvesoftware.Steam";
+        assert!(check_for_flatpak_run(cmdline, &xdg_list));
+    }
+
+    #[test]
+    fn test_check_for_flatpak_run_detects_command_flag() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("steam".to_string(), true);
+        let cmdline = "/usr/bin/flatpak\0run\0--command=steam\0com.example.App";
+        assert!(check_for_flatpak_run(cmdline, &xdg_list));
+    }
+
+    #[test]
+    fn test_check_for_flatpak_run_rejects_non_flatpak_binary() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("steam".to_string(), true);
+        let cmdline = "/usr/bin/niri\0msg\0steam";
+        assert!(!check_for_flatpak_run(cmdline, &xdg_list));
+    }
+
+    #[test]
+    fn test_check_for_flatpak_run_rejects_empty_cmdline() {
+        let xdg_list = HashMap::new();
+        assert!(!check_for_flatpak_run("", &xdg_list));
+    }
+
+    #[test]
+    fn test_check_for_flatpak_run_returns_false_for_unknown_app() {
+        let xdg_list = HashMap::new();
+        let cmdline = "/usr/bin/flatpak\0run\0com.unknown.App";
+        assert!(!check_for_flatpak_run(cmdline, &xdg_list));
+    }
+
+    #[test]
+    fn test_check_for_flatpak_run_detects_flatpak_wrapped() {
+        let mut xdg_list = HashMap::new();
+        xdg_list.insert("com.valvesoftware.Steam".to_string(), true);
+        let cmdline = "/app/bin/.flatpak-wrapped\0com.valvesoftware.Steam";
+        assert!(check_for_flatpak_run(cmdline, &xdg_list));
+    }
+
+    /*
+        check_cardwire_allow
+    */
+
+    #[test]
+    fn test_check_cardwire_allow_returns_true_for_allow_1() {
+        let environ = b"HOME=/home\0CARDWIRE_ALLOW=1\0DISPLAY=:0";
+        assert_eq!(check_cardwire_allow(environ), Some(true));
+    }
+
+    #[test]
+    fn test_check_cardwire_allow_returns_false_for_allow_0() {
+        let environ = b"HOME=/home\0CARDWIRE_ALLOW=0\0DISPLAY=:0";
+        assert_eq!(check_cardwire_allow(environ), Some(false));
+    }
+
+    #[test]
+    fn test_check_cardwire_allow_returns_none_when_absent() {
+        let environ = b"HOME=/home\0DISPLAY=:0";
+        assert_eq!(check_cardwire_allow(environ), None);
+    }
+
+    #[test]
+    fn test_check_cardwire_allow_returns_none_for_empty_input() {
+        assert_eq!(check_cardwire_allow(b""), None);
+    }
+
+    #[test]
+    fn test_check_cardwire_allow_returns_false_for_unexpected_value() {
+        // "CARDWIRE_ALLOW=x" — value at index 15 is 'x', not '1'
+        let environ = b"CARDWIRE_ALLOW=x";
+        assert_eq!(check_cardwire_allow(environ), Some(false));
+    }
+
+    /*
+        check_gpu_env
+    */
+
+    #[test]
+    fn test_check_gpu_env_detects_dri_prime_1() {
+        let environ = b"HOME=/home\0DRI_PRIME==1\0DISPLAY=:0";
+        assert!(check_gpu_env(environ));
+    }
+
+    #[test]
+    fn test_check_gpu_env_rejects_dri_prime_0() {
+        let environ = b"HOME=/home\0DRI_PRIME==0\0DISPLAY=:0";
+        assert!(!check_gpu_env(environ));
+    }
+
+    #[test]
+    fn test_check_gpu_env_detects_nv_prime_render_offload_1() {
+        let environ = b"__NV_PRIME_RENDER_OFFLOAD=1";
+        assert!(check_gpu_env(environ));
+    }
+
+    #[test]
+    fn test_check_gpu_env_rejects_nv_prime_render_offload_0() {
+        let environ = b"__NV_PRIME_RENDER_OFFLOAD=0";
+        assert!(!check_gpu_env(environ));
+    }
+
+    #[test]
+    fn test_check_gpu_env_returns_false_when_neither_present() {
+        let environ = b"HOME=/home\0DISPLAY=:0\0TERM=xterm";
+        assert!(!check_gpu_env(environ));
+    }
+
+    #[test]
+    fn test_check_gpu_env_returns_false_for_empty_input() {
+        assert!(!check_gpu_env(b""));
+    }
+}

--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -64,8 +64,8 @@ pub fn check_cardwire_allow(environ: &[u8]) -> Option<bool> {
 }
 pub fn check_gpu_env(environ: &[u8]) -> bool {
     for var in environ.split(|&b| b == 0) {
-        if var.starts_with(b"DRI_PRIME==") {
-            if var.get(11) == Some(&b'1') {
+        if var.starts_with(b"DRI_PRIME=") {
+            if var.get(10) == Some(&b'1') {
                 return true; // DRI_PRIME=1
             } else {
                 return false; // DRI_PRIME=0

--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -269,13 +269,13 @@ mod tests {
 
     #[test]
     fn test_check_gpu_env_detects_dri_prime_1() {
-        let environ = b"HOME=/home\0DRI_PRIME==1\0DISPLAY=:0";
+        let environ = b"HOME=/home\0DRI_PRIME=1\0DISPLAY=:0";
         assert!(check_gpu_env(environ));
     }
 
     #[test]
     fn test_check_gpu_env_rejects_dri_prime_0() {
-        let environ = b"HOME=/home\0DRI_PRIME==0\0DISPLAY=:0";
+        let environ = b"HOME=/home\0DRI_PRIME=0\0DISPLAY=:0";
         assert!(!check_gpu_env(environ));
     }
 

--- a/crates/cardwire-daemon/src/analyzer/models.rs
+++ b/crates/cardwire-daemon/src/analyzer/models.rs
@@ -285,3 +285,145 @@ fn get_real_process_name(pid: u32) -> Option<String> {
     let base_name = binary.split('/').next_back().unwrap_or(binary);
     Some(base_name.to_string())
 }
+
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    #[test]
+    fn test_event_deserialization_from_valid_bytes() {
+        let item: Vec<u8> = vec![
+            0x01, 0x00, 0x00, 0x00, // pid = 1
+        ];
+        assert!(item.len() >= std::mem::size_of::<Event>());
+        let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Event) };
+        assert_eq!(event.pid, 1);
+    }
+
+    #[test]
+    fn test_event_deserialization_rejects_undersized_buffer() {
+        let item: Vec<u8> = vec![0x01, 0x00, 0x00]; // 3 bytes, Event needs 4
+        assert!(item.len() < std::mem::size_of::<Event>());
+    }
+
+    #[test]
+    fn test_event_deserialization_with_large_pid() {
+        // pid = 0xFFFFFFFF (u32::MAX)
+        let item: Vec<u8> = vec![0xFF, 0xFF, 0xFF, 0xFF];
+        let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Event) };
+        assert_eq!(event.pid, u32::MAX);
+    }
+
+    #[test]
+    fn test_close_event_deserialization() {
+        let item: Vec<u8> = vec![
+            0x2A, 0x00, 0x00, 0x00, // pid = 42
+        ];
+        assert!(item.len() >= std::mem::size_of::<Close>());
+        let event = unsafe { ptr::read_unaligned(item.as_ptr() as *const Close) };
+        assert_eq!(event.pid, 42);
+    }
+
+    #[test]
+    fn test_get_real_process_name_returns_exe_for_wine_proton_cmdline() {
+        let cmdline_bytes =
+            r"S:\common\NieR·Replicant·ver.1.22474487139\NieR·Replicant·ver.1.22474487139.exe"
+                .as_bytes();
+
+        assert!(!cmdline_bytes.is_empty());
+        let args: Vec<&str> = cmdline_bytes
+            .split(|&b| b == 0)
+            .filter_map(|b| std::str::from_utf8(b).ok())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert!(!args.is_empty());
+        {
+            let binary = args[0];
+
+            // Check Wine/Proton
+            if binary.contains("wine") || binary.contains("proton") {
+                for arg in args.iter().skip(1) {
+                    if arg.to_lowercase().ends_with(".exe") {
+                        let file_name = arg.split(&['/', '\\'][..]).next_back().unwrap_or(arg);
+                        assert_eq!(file_name, "NieR·Replicant·ver.1.22474487139.exe");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_real_process_name_returns_jar_for_java_cmdline() {
+        let cmdline_bytes = "minecraft.jar".as_bytes();
+
+        assert!(!cmdline_bytes.is_empty());
+        let args: Vec<&str> = cmdline_bytes
+            .split(|&b| b == 0)
+            .filter_map(|b| std::str::from_utf8(b).ok())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert!(!args.is_empty());
+        {
+            let binary = args[0];
+
+            // Check Wine/Proton
+            if binary.ends_with(".java") {
+                for arg in args.iter().skip(1) {
+                    if arg.ends_with(".jar") {
+                        let file_name = arg.split('/').next_back().unwrap_or(arg);
+                        assert_eq!(file_name, "minecraft");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_real_process_name_returns_basename_for_regular_binary() {
+        // Simulate a regular binary like "/usr/bin/steam"
+        let cmdline_bytes = b"/usr/bin/steam\0--no-browser\0";
+        let args: Vec<&str> = cmdline_bytes
+            .split(|&b| b == 0)
+            .filter_map(|b| std::str::from_utf8(b).ok())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert!(!args.is_empty());
+        let binary = args[0];
+        let base_name = binary.split('/').next_back().unwrap_or(binary);
+        assert_eq!(base_name, "steam");
+    }
+
+    #[test]
+    fn test_get_real_process_name_returns_none_for_empty_cmdline() {
+        let cmdline_bytes = b"";
+        assert!(cmdline_bytes.is_empty());
+    }
+
+    #[test]
+    fn test_get_real_process_name_extracts_wine_exe_from_multiarg_cmdline() {
+        // Simulates: wine64-preloader\0C:\game\app.exe\0--fullscreen
+        let cmdline_bytes = b"wine64-preloader\0C:\\game\\app.exe\0--fullscreen";
+        let args: Vec<&str> = cmdline_bytes
+            .split(|&b| b == 0)
+            .filter_map(|b| std::str::from_utf8(b).ok())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let binary = args[0];
+        assert!(binary.contains("wine"));
+        // Find the .exe argument
+        let exe_arg = args
+            .iter()
+            .skip(1)
+            .find(|a| a.to_lowercase().ends_with(".exe"));
+        assert!(exe_arg.is_some());
+        let file_name = exe_arg
+            .unwrap()
+            .split(&['/', '\\'][..])
+            .next_back()
+            .unwrap();
+        assert_eq!(file_name, "app.exe");
+    }
+}

--- a/crates/cardwire-daemon/src/core/errors.rs
+++ b/crates/cardwire-daemon/src/core/errors.rs
@@ -32,3 +32,49 @@ impl From<&str> for Error {
         Error::Other(s.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_from_str() {
+        let err = Error::from("something went wrong");
+        match err {
+            Error::Other(msg) => assert_eq!(msg, "something went wrong"),
+            _ => panic!("expected Error::Other"),
+        }
+    }
+
+    #[test]
+    fn test_error_display_iommu_not_enabled() {
+        let err = Error::IommuNotEnabled;
+        assert_eq!(err.to_string(), "IOMMU Not Enabled");
+    }
+
+    #[test]
+    fn test_error_display_missing_devices_dir() {
+        let err = Error::MissingDevicesDir(std::path::PathBuf::from("/sys/test"));
+        assert!(err.to_string().contains("/sys/test"));
+    }
+
+    #[test]
+    fn test_error_display_io_error() {
+        let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
+        let err = Error::Io(io_err);
+        assert!(err.to_string().contains("file not found"));
+    }
+
+    #[test]
+    fn test_error_display_parse_int() {
+        let parse_err = "abc".parse::<u32>().unwrap_err();
+        let err = Error::ParseInt(parse_err);
+        assert!(err.to_string().contains("parse"));
+    }
+
+    #[test]
+    fn test_error_display_other() {
+        let err = Error::Other("custom error".to_string());
+        assert_eq!(err.to_string(), "custom error");
+    }
+}

--- a/crates/cardwire-daemon/src/core/gpu/models.rs
+++ b/crates/cardwire-daemon/src/core/gpu/models.rs
@@ -146,3 +146,196 @@ pub struct DbusGpuDevice {
     pub nvidia: bool,
     pub nvidia_minor: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::pci::PciDevice;
+
+    fn make_pci() -> PciDevice {
+        PciDevice::new(
+            "0000:01:00.0".to_string(),
+            Some(1),
+            Some("0x1002".to_string()),
+            Some("0x1234".to_string()),
+            Some("AMD".to_string()),
+            Some("RX 7900".to_string()),
+            Some("amdgpu".to_string()),
+            Some("0x030000".to_string()),
+            None,
+            None,
+        )
+    }
+
+    /*
+        PowerState enum
+    */
+
+    #[test]
+    fn test_power_state_from_str_all_valid_variants() {
+        assert_eq!("D0".parse::<PowerState>().unwrap(), PowerState::D0);
+        assert_eq!("D1".parse::<PowerState>().unwrap(), PowerState::D1);
+        assert_eq!("D2".parse::<PowerState>().unwrap(), PowerState::D2);
+        assert_eq!("D3hot".parse::<PowerState>().unwrap(), PowerState::D3Hot);
+        assert_eq!("D3cold".parse::<PowerState>().unwrap(), PowerState::D3Cold);
+    }
+
+    #[test]
+    fn test_power_state_from_str_unknown_input() {
+        assert_eq!("D4".parse::<PowerState>().unwrap(), PowerState::Unknown);
+        assert_eq!("".parse::<PowerState>().unwrap(), PowerState::Unknown);
+        assert_eq!(
+            "garbage".parse::<PowerState>().unwrap(),
+            PowerState::Unknown
+        );
+    }
+
+    #[test]
+    fn test_power_state_display_roundtrip() {
+        assert_eq!(PowerState::D0.to_string(), "D0");
+        assert_eq!(PowerState::D1.to_string(), "D1");
+        assert_eq!(PowerState::D2.to_string(), "D2");
+        assert_eq!(PowerState::D3Hot.to_string(), "D3Hot");
+        assert_eq!(PowerState::D3Cold.to_string(), "D3Cold");
+        assert_eq!(PowerState::Unknown.to_string(), "unknown");
+    }
+
+    #[test]
+    fn test_power_state_default_is_unknown() {
+        assert_eq!(PowerState::default(), PowerState::Unknown);
+    }
+
+    /*
+        GpuVendor
+    */
+
+    #[test]
+    fn test_gpu_vendor_from_amd_id() {
+        assert_eq!(GpuVendor::from("0x1002"), GpuVendor::Amd);
+    }
+
+    #[test]
+    fn test_gpu_vendor_from_nvidia_primary_id() {
+        assert_eq!(GpuVendor::from("0x10de"), GpuVendor::Nvidia);
+    }
+
+    #[test]
+    fn test_gpu_vendor_from_nvidia_alternate_ids() {
+        assert_eq!(GpuVendor::from("0x104a"), GpuVendor::Nvidia);
+        assert_eq!(GpuVendor::from("0x12d2"), GpuVendor::Nvidia);
+    }
+
+    #[test]
+    fn test_gpu_vendor_from_intel_id() {
+        assert_eq!(GpuVendor::from("0x8086"), GpuVendor::Intel);
+    }
+
+    #[test]
+    fn test_gpu_vendor_from_unknown_id() {
+        assert_eq!(GpuVendor::from("0x0000"), GpuVendor::Other);
+        assert_eq!(GpuVendor::from("invalid"), GpuVendor::Other);
+    }
+
+    #[test]
+    fn test_gpu_vendor_default_is_other() {
+        assert_eq!(GpuVendor::default(), GpuVendor::Other);
+    }
+
+    /*
+    GpuDevice
+    */
+
+    #[test]
+    fn test_gpu_device_accessors_return_constructed_values() {
+        let pci = make_pci();
+        let gpu = GpuDevice::new(
+            "RX 7900 XTX".to_string(),
+            pci,
+            128,
+            0,
+            Some(true),
+            GpuVendor::Amd,
+            None,
+        );
+        assert_eq!(gpu.name(), "RX 7900 XTX");
+        assert_eq!(*gpu.render(), 128);
+        assert_eq!(*gpu.card(), 0);
+        assert_eq!(gpu.default(), Some(true));
+        assert_eq!(gpu.gpu_vendor(), GpuVendor::Amd);
+        assert_eq!(*gpu.nvidia_minor(), None);
+        assert_eq!(gpu.pci().pci_address(), "0000:01:00.0");
+    }
+
+    #[test]
+    fn test_gpu_device_is_default_true() {
+        let gpu = GpuDevice::new(
+            "GPU".to_string(),
+            make_pci(),
+            128,
+            0,
+            Some(true),
+            GpuVendor::Amd,
+            None,
+        );
+        assert!(gpu.is_default());
+    }
+
+    #[test]
+    fn test_gpu_device_is_default_false() {
+        let gpu = GpuDevice::new(
+            "GPU".to_string(),
+            make_pci(),
+            128,
+            0,
+            Some(false),
+            GpuVendor::Amd,
+            None,
+        );
+        assert!(!gpu.is_default());
+    }
+
+    #[test]
+    fn test_gpu_device_is_default_none_returns_false() {
+        let gpu = GpuDevice::new(
+            "GPU".to_string(),
+            make_pci(),
+            128,
+            0,
+            None,
+            GpuVendor::Amd,
+            None,
+        );
+        assert!(!gpu.is_default());
+    }
+
+    #[test]
+    fn test_gpu_device_set_default() {
+        let mut gpu = GpuDevice::new(
+            "GPU".to_string(),
+            make_pci(),
+            128,
+            0,
+            None,
+            GpuVendor::Amd,
+            None,
+        );
+        assert!(!gpu.is_default());
+        gpu.set_default(Some(true));
+        assert!(gpu.is_default());
+    }
+
+    #[test]
+    fn test_gpu_device_with_nvidia_minor() {
+        let gpu = GpuDevice::new(
+            "RTX 4090".to_string(),
+            make_pci(),
+            128,
+            0,
+            Some(false),
+            GpuVendor::Nvidia,
+            Some(0),
+        );
+        assert_eq!(gpu.gpu_vendor(), GpuVendor::Nvidia);
+        assert_eq!(*gpu.nvidia_minor(), Some(0));
+    }
+}

--- a/crates/cardwire-daemon/src/core/pci/models.rs
+++ b/crates/cardwire-daemon/src/core/pci/models.rs
@@ -90,3 +90,60 @@ pub struct IommuGroup {
     pub id: usize,
     pub devices: Vec<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pci_device_accessors_return_constructed_values() {
+        let pci = PciDevice::new(
+            "0000:01:00.0".to_string(),
+            Some(5),
+            Some("0x1002".to_string()),
+            Some("0x7480".to_string()),
+            Some("AMD".to_string()),
+            Some("Navi 31".to_string()),
+            Some("amdgpu".to_string()),
+            Some("0x030000".to_string()),
+            Some("0000:00:01.0".to_string()),
+            Some("0000:01:00.1".to_string()),
+        );
+        assert_eq!(pci.pci_address(), "0000:01:00.0");
+        assert_eq!(*pci.iommu_group(), Some(5));
+        assert_eq!(pci.vendor_id().as_deref(), Some("0x1002"));
+        assert_eq!(pci.device_id().as_deref(), Some("0x7480"));
+        assert_eq!(pci.vendor_name().as_deref(), Some("AMD"));
+        assert_eq!(pci.device_name().as_deref(), Some("Navi 31"));
+        assert_eq!(pci.driver().as_deref(), Some("amdgpu"));
+        assert_eq!(pci.class().as_deref(), Some("0x030000"));
+        assert_eq!(pci.parent_pci().as_deref(), Some("0000:00:01.0"));
+        assert_eq!(pci.child_pci().as_deref(), Some("0000:01:00.1"));
+    }
+
+    #[test]
+    fn test_pci_device_with_all_none_fields() {
+        let pci = PciDevice::new(
+            "0000:02:00.0".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(pci.pci_address(), "0000:02:00.0");
+        assert_eq!(*pci.iommu_group(), None);
+        assert_eq!(pci.vendor_id().as_deref(), None);
+        assert_eq!(pci.device_id().as_deref(), None);
+        assert_eq!(pci.vendor_name().as_deref(), None);
+        assert_eq!(pci.device_name().as_deref(), None);
+        assert_eq!(pci.driver().as_deref(), None);
+        assert_eq!(pci.class().as_deref(), None);
+        assert_eq!(pci.parent_pci().as_deref(), None);
+        assert_eq!(pci.child_pci().as_deref(), None);
+    }
+}

--- a/crates/cardwire-daemon/src/file/config.rs
+++ b/crates/cardwire-daemon/src/file/config.rs
@@ -84,3 +84,78 @@ impl CardwireConfig {
         self.battery_auto_switch_mode
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interface::Modes;
+
+    #[test]
+    fn test_cardwire_config_default_values() {
+        let config = CardwireConfig::default();
+        assert!(config.auto_apply_gpu_state());
+        assert!(!config.experimental_nvidia_block());
+        assert!(!config.battery_auto_switch());
+        assert_eq!(config.battery_auto_switch_mode(), Modes::Hybrid);
+    }
+
+    #[test]
+    fn test_cardwire_config_build_values() {
+        let config = CardwireConfig::new(false, true, true, Modes::Smart);
+        assert!(!config.auto_apply_gpu_state());
+        assert!(config.experimental_nvidia_block());
+        assert!(config.battery_auto_switch());
+        assert_eq!(config.battery_auto_switch_mode(), Modes::Smart);
+    }
+
+    #[test]
+    fn test_cardwire_config_toml_roundtrip() {
+        let config = CardwireConfig::default();
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: CardwireConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.auto_apply_gpu_state(), config.auto_apply_gpu_state());
+        assert_eq!(
+            parsed.experimental_nvidia_block(),
+            config.experimental_nvidia_block()
+        );
+        assert_eq!(parsed.battery_auto_switch(), config.battery_auto_switch());
+        assert_eq!(
+            parsed.battery_auto_switch_mode(),
+            config.battery_auto_switch_mode()
+        );
+    }
+
+    #[test]
+    fn test_cardwire_config_toml_parse_with_missing_fields_uses_defaults() {
+        // Only specify one field — serde(default) should fill the rest
+        let toml_str = "auto_apply_gpu_state = false\n";
+        let parsed: CardwireConfig = toml::from_str(toml_str).unwrap();
+        assert!(!parsed.auto_apply_gpu_state());
+        // All others should be defaults
+        assert!(!parsed.experimental_nvidia_block());
+        assert!(!parsed.battery_auto_switch());
+        assert_eq!(parsed.battery_auto_switch_mode(), Modes::Hybrid);
+    }
+
+    #[test]
+    fn test_cardwire_config_toml_parse_empty_string_uses_all_defaults() {
+        let parsed: CardwireConfig = toml::from_str("").unwrap();
+        assert!(parsed.auto_apply_gpu_state());
+        assert!(!parsed.experimental_nvidia_block());
+    }
+
+    #[test]
+    fn test_cardwire_config_toml_with_custom_values() {
+        let toml_str = r#"
+auto_apply_gpu_state = false
+experimental_nvidia_block = true
+battery_auto_switch = true
+battery_auto_switch_mode = "smart"
+"#;
+        let parsed: CardwireConfig = toml::from_str(toml_str).unwrap();
+        assert!(!parsed.auto_apply_gpu_state());
+        assert!(parsed.experimental_nvidia_block());
+        assert!(parsed.battery_auto_switch());
+        assert_eq!(parsed.battery_auto_switch_mode(), Modes::Smart);
+    }
+}

--- a/crates/cardwire-daemon/src/file/state.rs
+++ b/crates/cardwire-daemon/src/file/state.rs
@@ -142,3 +142,88 @@ impl CardwireGpuState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interface::Modes;
+
+    /*
+        CardwireModeState
+    */
+
+    #[test]
+    fn test_mode_state_default_is_manual() {
+        let state = CardwireModeState::default();
+        assert_eq!(state.mode(), Modes::Manual);
+    }
+
+    #[test]
+    fn test_mode_state_json_roundtrip() {
+        let state = CardwireModeState::default();
+        let json = serde_json::to_string_pretty(&state).unwrap();
+        let parsed: CardwireModeState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.mode(), state.mode());
+    }
+
+    #[test]
+    fn test_mode_state_json_parse_with_integrated_mode() {
+        let json = r#"{"mode":"integrated"}"#;
+        let parsed: CardwireModeState = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.mode(), Modes::Integrated);
+    }
+
+    #[test]
+    fn test_mode_state_json_parse_empty_uses_defaults() {
+        let json = "{}";
+        let parsed: CardwireModeState = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.mode(), Modes::Manual);
+    }
+
+    /*
+        CardwireGpuState
+    */
+
+    #[test]
+    fn test_gpu_state_default_contains_null() {
+        let state = CardwireGpuState::default();
+        assert!(state.is_default_state());
+    }
+
+    #[test]
+    fn test_gpu_state_is_default_state_false_after_custom_data() {
+        let json = r#"{"0000:01:00.0":{"block":true}}"#;
+        let gpu: BTreeMap<String, CardwireGpuUnit> = serde_json::from_str(json).unwrap();
+        let state = CardwireGpuState { gpu };
+        assert!(!state.is_default_state());
+    }
+
+    #[test]
+    fn test_gpu_state_gpu_block_state_returns_false_for_missing_key() {
+        let state = CardwireGpuState::default();
+        assert!(!state.gpu_block_state("0000:99:00.0"));
+    }
+
+    #[test]
+    fn test_gpu_state_gpu_block_state_returns_correct_value() {
+        let json = r#"{"0000:01:00.0":{"block":true},"0000:02:00.0":{"block":false}}"#;
+        let gpu: BTreeMap<String, CardwireGpuUnit> = serde_json::from_str(json).unwrap();
+        let state = CardwireGpuState { gpu };
+        assert!(state.gpu_block_state("0000:01:00.0"));
+        assert!(!state.gpu_block_state("0000:02:00.0"));
+    }
+
+    #[test]
+    fn test_gpu_unit_default_block_is_false() {
+        let unit = CardwireGpuUnit::default();
+        assert!(!unit.block);
+    }
+
+    #[test]
+    fn test_gpu_state_json_roundtrip() {
+        let state = CardwireGpuState::default();
+        let json = serde_json::to_string_pretty(&state.gpu).unwrap();
+        let parsed: BTreeMap<String, CardwireGpuUnit> = serde_json::from_str(&json).unwrap();
+        assert!(parsed.contains_key("Null"));
+    }
+}

--- a/crates/cardwire-daemon/src/interface/config.rs
+++ b/crates/cardwire-daemon/src/interface/config.rs
@@ -139,3 +139,38 @@ impl ConfigInterface {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file::CardwireConfig;
+
+    #[test]
+    fn test_config_memory_build_from_default_config() {
+        let config = CardwireConfig::default();
+        let memory = ConfigMemory::build(config);
+        assert!(memory.auto_apply_gpu_state.load(Ordering::Relaxed));
+        assert!(!memory.experimental_nvidia_block.load(Ordering::Relaxed));
+        assert!(!memory.battery_auto_switch.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_config_memory_build_from_custom_config() {
+        let config = CardwireConfig::new(false, true, true, Modes::Smart);
+        let memory = ConfigMemory::build(config);
+        assert!(!memory.auto_apply_gpu_state.load(Ordering::Relaxed));
+        assert!(memory.experimental_nvidia_block.load(Ordering::Relaxed));
+        assert!(memory.battery_auto_switch.load(Ordering::Relaxed));
+        let mode_val = memory.battery_auto_switch_mode.load(Ordering::Relaxed);
+        assert_eq!(Modes::try_from(mode_val).unwrap(), Modes::Smart);
+    }
+
+    #[test]
+    fn test_config_memory_atomic_store_and_load() {
+        let config = CardwireConfig::default();
+        let memory = ConfigMemory::build(config);
+        // Mutate the atomic
+        memory.auto_apply_gpu_state.store(false, Ordering::Relaxed);
+        assert!(!memory.auto_apply_gpu_state.load(Ordering::Relaxed));
+    }
+}

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -175,3 +175,67 @@ impl ModeInterface {
         Ok(Modes::into(current_mode.mode()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_modes_try_from_valid_values() {
+        assert_eq!(Modes::try_from(0).unwrap(), Modes::Integrated);
+        assert_eq!(Modes::try_from(1).unwrap(), Modes::Hybrid);
+        assert_eq!(Modes::try_from(2).unwrap(), Modes::Manual);
+        assert_eq!(Modes::try_from(3).unwrap(), Modes::Smart);
+    }
+
+    #[test]
+    fn test_modes_try_from_invalid_value() {
+        assert!(Modes::try_from(4).is_err());
+        assert!(Modes::try_from(u32::MAX).is_err());
+    }
+
+    #[test]
+    fn test_modes_into_u32_roundtrip() {
+        for i in 0..=3u32 {
+            let mode = Modes::try_from(i).unwrap();
+            let back: u32 = mode.into();
+            assert_eq!(back, i);
+        }
+    }
+
+    #[test]
+    fn test_modes_display_formatting() {
+        assert_eq!(Modes::Integrated.to_string(), "Integrated");
+        assert_eq!(Modes::Hybrid.to_string(), "Hybrid");
+        assert_eq!(Modes::Manual.to_string(), "Manual");
+        assert_eq!(Modes::Smart.to_string(), "Smart");
+    }
+
+    #[test]
+    fn test_modes_default_is_manual() {
+        assert_eq!(Modes::default(), Modes::Manual);
+    }
+
+    #[test]
+    fn test_modes_serde_json_roundtrip() {
+        let modes = [
+            Modes::Integrated,
+            Modes::Hybrid,
+            Modes::Manual,
+            Modes::Smart,
+        ];
+        for mode in modes {
+            let json = serde_json::to_string(&mode).unwrap();
+            let deserialized: Modes = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, mode);
+        }
+    }
+
+    #[test]
+    fn test_modes_serde_uses_snake_case() {
+        let json = serde_json::to_string(&Modes::Integrated).unwrap();
+        assert_eq!(json, "\"integrated\"");
+        let json = serde_json::to_string(&Modes::Hybrid).unwrap();
+        assert_eq!(json, "\"hybrid\"");
+    }
+}

--- a/crates/cardwire-ebpf/src/errors.rs
+++ b/crates/cardwire-ebpf/src/errors.rs
@@ -40,3 +40,61 @@ impl CardwireEbpfError {
 }
 
 pub type CardwireEbpfResult<T> = Result<T, CardwireEbpfError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display_lsm_not_enabled() {
+        let err = CardwireEbpfError::LSMNotEnabled;
+        assert_eq!(err.to_string(), "LSM not enabled");
+    }
+
+    #[test]
+    fn test_error_missing_lsm_named() {
+        let err = CardwireEbpfError::missing_lsm("file_open");
+        assert_eq!(err.to_string(), "missing lsm: file_open");
+    }
+
+    #[test]
+    fn test_error_missing_map_named() {
+        let err = CardwireEbpfError::missing_map("cw_blocked_ino");
+        assert_eq!(err.to_string(), "missing map: cw_blocked_ino");
+    }
+
+    #[test]
+    fn test_error_aya_wraps_message() {
+        let err = CardwireEbpfError::aya("some aya error");
+        assert_eq!(err.to_string(), "some aya error");
+    }
+
+    #[test]
+    fn test_error_ebpf_load_error() {
+        let err = CardwireEbpfError::EbpfLoadError("failed to load".to_string());
+        assert!(err.to_string().contains("failed to load"));
+    }
+
+    #[test]
+    fn test_error_wrong_format() {
+        let err = CardwireEbpfError::WrongFormat {
+            kind: "PCI address".to_string(),
+            input: "invalid".to_string(),
+        };
+        assert!(err.to_string().contains("PCI address"));
+        assert!(err.to_string().contains("invalid"));
+    }
+
+    #[test]
+    fn test_error_io_conversion() {
+        let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "access denied");
+        let err = CardwireEbpfError::from(io_err);
+        assert!(err.to_string().contains("access denied"));
+    }
+
+    #[test]
+    fn test_error_other() {
+        let err = CardwireEbpfError::Other("custom".to_string());
+        assert_eq!(err.to_string(), "custom");
+    }
+}


### PR DESCRIPTION
# Description

Add tests for all crates to improve the test coverage of cardwire and prevent regression

# TODO

- [x] Implement cargo tests
- [x] Add a cargo test workflow into the ci

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
