### PR TITLE
feat(cardwired): accurate name detection for nvidia and amd

### DIFF
--- a/crates/cardwire-daemon/src/core/gpu/discover.rs
+++ b/crates/cardwire-daemon/src/core/gpu/discover.rs
@@ -46,11 +46,22 @@ fn build_gpu(device: &PciDevice) -> io::Result<GpuDevice> {
         _ => None,
     };
 
-    // if None use a default placeholder name
-    let device_name = device
-        .device_name()
-        .clone()
-        .unwrap_or_else(|| "Unknown Device".to_string());
+    let device_name = match gpu_vendor {
+        GpuVendor::Nvidia => nvidia_get_device_model(device.pci_address()),
+        GpuVendor::Amd => match device.device_id() {
+            Some(id) => amd_get_device_mode(&id, device.pci_address()),
+            None => None,
+        },
+        _ => None,
+    }
+    // If none, just use the hwdata name or a placeholder
+    .unwrap_or_else(|| {
+        warn!("Couldn't get device_name, falling back to hwdata");
+        device.device_name().clone().unwrap_or_else(|| {
+            warn!("Couldn't get name using hwdata, falling back to default");
+            "Unknown Device".to_string()
+        })
+    });
 
     Ok(GpuDevice::new(
         device_name,
@@ -158,6 +169,64 @@ fn nvidia_get_minor(pci_address: &str) -> Option<u32> {
         .parse::<u32>()
         .ok()
 }
+fn nvidia_get_device_model(pci_address: &str) -> Option<String> {
+    let nvidia_driver_proc = Path::new("/proc/driver/nvidia/gpus/")
+        .join(pci_address)
+        .join("information");
+    let information = fs::read_to_string(nvidia_driver_proc).ok()?;
+    let model = information
+        .lines()
+        .find(|line| line.starts_with("Model:"))?
+        .split_once(':')?
+        .1
+        .trim()
+        .to_string();
+    match !model.is_empty() {
+        true => Some(model),
+        false => None,
+    }
+}
+
+fn amd_get_device_mode(device_id: &str, pci: &str) -> Option<String> {
+    let path = Path::new("/usr/share/libdrm/amdgpu.ids");
+    let path = Path::new(
+        "/nix/store/i7j9cxklwxjm54qx1y2s172bz4irqfbh-libdrm-2.4.134/share/libdrm/amdgpu.ids",
+    );
+    let device_id = device_id.to_string().replace("0x", "").to_ascii_uppercase();
+    let revision_path = format!("/sys/bus/pci/devices/{}/revision", pci);
+    let revision_id = fs::read_to_string(revision_path)
+        .ok()?
+        .replace("0x", "")
+        .to_ascii_uppercase();
+    match fs::read_to_string(path) {
+        Ok(content) => {
+            let model_lines: Vec<&str> = content
+                .lines()
+                .filter(|line| line.starts_with(&device_id))
+                .collect();
+            println!("revision: {}", &revision_id.trim());
+            println!("device lines: {:?}", model_lines);
+            let device_name = model_lines.iter().find(|line| {
+                line.split("\t").nth(1).is_some_and(|rev| {
+                    println!(
+                        "trying {} with {} got {}",
+                        rev,
+                        revision_id,
+                        rev == revision_id
+                    );
+                    rev.eq_ignore_ascii_case(&revision_id)
+                })
+            })?;
+            println!("device_name: {}", device_name);
+            None
+        }
+        Err(err) => {
+            warn!("couldn't read amdgpu.ids: {}", err);
+            None
+        }
+    }
+}
+
 /// Method from kwin
 pub fn check_default_drm_class(gpu_list: &mut BTreeMap<usize, GpuInterface>) -> io::Result<()> {
     // skip if empty

--- a/crates/cardwire-daemon/src/core/gpu/discover.rs
+++ b/crates/cardwire-daemon/src/core/gpu/discover.rs
@@ -189,9 +189,6 @@ fn nvidia_get_device_model(pci_address: &str) -> Option<String> {
 
 fn amd_get_device_mode(device_id: &str, pci: &str) -> Option<String> {
     let path = Path::new("/usr/share/libdrm/amdgpu.ids");
-    let path = Path::new(
-        "/nix/store/i7j9cxklwxjm54qx1y2s172bz4irqfbh-libdrm-2.4.134/share/libdrm/amdgpu.ids",
-    );
     let device_id = device_id.to_string().replace("0x", "").to_ascii_uppercase();
     let revision_path = format!("/sys/bus/pci/devices/{}/revision", pci);
     let revision_id = fs::read_to_string(revision_path)

--- a/crates/cardwire-daemon/src/core/gpu/discover.rs
+++ b/crates/cardwire-daemon/src/core/gpu/discover.rs
@@ -169,6 +169,8 @@ fn nvidia_get_minor(pci_address: &str) -> Option<u32> {
         .parse::<u32>()
         .ok()
 }
+
+/// find the nvidai model using the device information file
 fn nvidia_get_device_model(pci_address: &str) -> Option<String> {
     let nvidia_driver_proc = Path::new("/proc/driver/nvidia/gpus/")
         .join(pci_address)
@@ -187,6 +189,7 @@ fn nvidia_get_device_model(pci_address: &str) -> Option<String> {
     }
 }
 
+/// Find the amd model using amdgpu.ids, require the device id and the revision for precise matching
 fn amd_get_device_model(device_id: &str, pci: &str) -> Option<String> {
     let path = "/usr/share/libdrm/amdgpu.ids";
     let device_id = device_id.to_string().replace("0x", "").to_ascii_uppercase();

--- a/crates/cardwire-daemon/src/core/gpu/discover.rs
+++ b/crates/cardwire-daemon/src/core/gpu/discover.rs
@@ -49,7 +49,7 @@ fn build_gpu(device: &PciDevice) -> io::Result<GpuDevice> {
     let device_name = match gpu_vendor {
         GpuVendor::Nvidia => nvidia_get_device_model(device.pci_address()),
         GpuVendor::Amd => match device.device_id() {
-            Some(id) => amd_get_device_mode(&id, device.pci_address()),
+            Some(id) => amd_get_device_model(id, device.pci_address()),
             None => None,
         },
         _ => None,
@@ -187,41 +187,43 @@ fn nvidia_get_device_model(pci_address: &str) -> Option<String> {
     }
 }
 
-fn amd_get_device_mode(device_id: &str, pci: &str) -> Option<String> {
-    let path = Path::new("/usr/share/libdrm/amdgpu.ids");
+fn amd_get_device_model(device_id: &str, pci: &str) -> Option<String> {
+    let paths = [
+        "/usr/share/libdrm/amdgpu.ids",
+        "/nix/store/i7j9cxklwxjm54qx1y2s172bz4irqfbh-libdrm-2.4.134/share/libdrm/amdgpu.ids",
+    ];
     let device_id = device_id.to_string().replace("0x", "").to_ascii_uppercase();
-    let revision_path = format!("/sys/bus/pci/devices/{}/revision", pci);
-    let revision_id = fs::read_to_string(revision_path)
+
+    let revision = fs::read_to_string(format!("/sys/bus/pci/devices/{}/revision", pci))
         .ok()?
+        .trim()
         .replace("0x", "")
         .to_ascii_uppercase();
-    match fs::read_to_string(path) {
-        Ok(content) => {
-            let model_lines: Vec<&str> = content
-                .lines()
-                .filter(|line| line.starts_with(&device_id))
-                .collect();
-            println!("revision: {}", &revision_id.trim());
-            println!("device lines: {:?}", model_lines);
-            let device_name = model_lines.iter().find(|line| {
-                line.split("\t").nth(1).is_some_and(|rev| {
-                    println!(
-                        "trying {} with {} got {}",
-                        rev,
-                        revision_id,
-                        rev == revision_id
-                    );
-                    rev.eq_ignore_ascii_case(&revision_id)
-                })
-            })?;
-            println!("device_name: {}", device_name);
-            None
+
+    let content = paths.iter().find_map(|p| fs::read_to_string(p).ok())?;
+
+    for line in content.lines() {
+        if line.starts_with('#') {
+            continue;
         }
-        Err(err) => {
-            warn!("couldn't read amdgpu.ids: {}", err);
-            None
+
+        let mut parts = line.split('\t');
+        let Some(id) = parts.next() else {
+            continue;
+        };
+        let Some(rev) = parts.next() else {
+            continue;
+        };
+        let Some(name) = parts.next() else {
+            continue;
+        };
+
+        if id.trim_end_matches(',') == device_id && rev.trim_end_matches(',') == revision {
+            return Some(name.to_string());
         }
     }
+
+    None
 }
 
 /// Method from kwin

--- a/crates/cardwire-daemon/src/core/gpu/discover.rs
+++ b/crates/cardwire-daemon/src/core/gpu/discover.rs
@@ -188,10 +188,7 @@ fn nvidia_get_device_model(pci_address: &str) -> Option<String> {
 }
 
 fn amd_get_device_model(device_id: &str, pci: &str) -> Option<String> {
-    let paths = [
-        "/usr/share/libdrm/amdgpu.ids",
-        "/nix/store/i7j9cxklwxjm54qx1y2s172bz4irqfbh-libdrm-2.4.134/share/libdrm/amdgpu.ids",
-    ];
+    let path = "/usr/share/libdrm/amdgpu.ids";
     let device_id = device_id.to_string().replace("0x", "").to_ascii_uppercase();
 
     let revision = fs::read_to_string(format!("/sys/bus/pci/devices/{}/revision", pci))
@@ -200,7 +197,7 @@ fn amd_get_device_model(device_id: &str, pci: &str) -> Option<String> {
         .replace("0x", "")
         .to_ascii_uppercase();
 
-    let content = paths.iter().find_map(|p| fs::read_to_string(p).ok())?;
+    let content = fs::read_to_string(p).ok()?;
 
     for line in content.lines() {
         if line.starts_with('#') {

--- a/crates/cardwire-daemon/src/core/gpu/discover.rs
+++ b/crates/cardwire-daemon/src/core/gpu/discover.rs
@@ -197,7 +197,7 @@ fn amd_get_device_model(device_id: &str, pci: &str) -> Option<String> {
         .replace("0x", "")
         .to_ascii_uppercase();
 
-    let content = fs::read_to_string(p).ok()?;
+    let content = fs::read_to_string(path).ok()?;
 
     for line in content.lines() {
         if line.starts_with('#') {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -45,7 +45,10 @@ in
     # Point to the correct hwdata location
     postPatch = ''
       substituteInPlace crates/cardwire-daemon/src/core/pci/pci_device.rs \
-      --replace "/usr/share/hwdata/pci.ids" "${pkgs.hwdata}/share/hwdata/pci.ids"
+        --replace "/usr/share/hwdata/pci.ids" "${pkgs.hwdata}/share/hwdata/pci.ids"
+
+      substituteInPlace crates/cardwire-daemon/src/core/gpu/discover.rs \
+        --replace "/usr/share/libdrm/amdgpu.ids" "${pkgs.libdrm}/share/libdrm/amdgpu.ids"
     '';
     # Copy dbus conf, systemd service and make shell completion
     postInstall = ''


### PR DESCRIPTION
# Description

Get a real and precise model name for nvidia and amd gpu, only use hwdata as a fallback

Fixes # (issue)

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU model name detection for both NVIDIA and AMD devices using vendor-specific sources.
  * Added a robust fallback to hardware data when vendor detection is unavailable or fails, returning a safe “Unknown Device” when needed.
  * Enhanced diagnostics to make GPU identification issues easier to understand.
* **Chores**
  * Adjusted bundled paths to ensure GPU ID database files are referenced from the correct runtime location during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->