### PR TITLE
feat: add CARDWIRE_FORCE_DGPU to cardwire

### DIFF
--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -89,6 +89,21 @@ pub fn check_cardwire_allow(environ: &[u8]) -> Option<bool> {
     // Not present
     None
 }
+
+pub fn check_cardwire_force_dgpu(environ: &[u8]) -> Option<bool> {
+    for var in environ.split(|&b| b == 0) {
+        if var.starts_with(b"CARDWIRE_FORCE_DGPU=") {
+            if var.get(20) == Some(&b'1') {
+                return Some(true); // CARDWIRE_FORCE_DGPU=1
+            } else {
+                return Some(false); // CARDWIRE_FORCE_DGPU=0
+            }
+        }
+    }
+    // Not present
+    None
+}
+
 pub fn check_gpu_env(environ: &[u8]) -> bool {
     for var in environ.split(|&b| b == 0) {
         if var.starts_with(b"DRI_PRIME=") {

--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -76,24 +76,13 @@ pub fn check_for_flatpak_run(cmdline: &str, xdg_list: &HashMap<String, bool>) ->
     false
 }
 
-pub fn check_cardwire_allow(environ: &[u8]) -> Option<bool> {
-    for var in environ.split(|&b| b == 0) {
-        if var.starts_with(b"CARDWIRE_ALLOW=") {
-            if var.get(15) == Some(&b'1') {
-                return Some(true); // CARDWIRE_ALLOW=1
-            } else {
-                return Some(false); // CARDWIRE_ALLOW=0
-            }
-        }
-    }
-    // Not present
-    None
-}
+pub fn check_env(env_var: &str, environ: &[u8]) -> Option<bool> {
+    let env_var = format!("{}=", env_var);
+    let env_var_len = env_var.len();
 
-pub fn check_cardwire_force_dgpu(environ: &[u8]) -> Option<bool> {
     for var in environ.split(|&b| b == 0) {
-        if var.starts_with(b"CARDWIRE_FORCE_DGPU=") {
-            if var.get(20) == Some(&b'1') {
+        if var.starts_with(env_var.as_bytes()) {
+            if var.get(env_var_len) == Some(&b'1') {
                 return Some(true); // CARDWIRE_FORCE_DGPU=1
             } else {
                 return Some(false); // CARDWIRE_FORCE_DGPU=0
@@ -338,37 +327,43 @@ mod tests {
     }
 
     /*
-        check_cardwire_allow
+        check_env
     */
 
     #[test]
-    fn test_check_cardwire_allow_returns_true_for_allow_1() {
+    fn test_check_env_returns_true_for_allow_1() {
         let environ = b"HOME=/home\0CARDWIRE_ALLOW=1\0DISPLAY=:0";
-        assert_eq!(check_cardwire_allow(environ), Some(true));
+        assert_eq!(check_env("CARDWIRE_ALLOW", environ), Some(true));
     }
 
     #[test]
-    fn test_check_cardwire_allow_returns_false_for_allow_0() {
+    fn test_check_env_returns_true_for_allow_1_dgpu() {
+        let environ = b"HOME=/home\0CARDWIRE_FORCE_DGPU=1\0DISPLAY=:0";
+        assert_eq!(check_env("CARDWIRE_FORCE_DGPU", environ), Some(true));
+    }
+
+    #[test]
+    fn test_check_env_returns_false_for_allow_0() {
         let environ = b"HOME=/home\0CARDWIRE_ALLOW=0\0DISPLAY=:0";
-        assert_eq!(check_cardwire_allow(environ), Some(false));
+        assert_eq!(check_env("CARDWIRE_ALLOW", environ), Some(false));
     }
 
     #[test]
-    fn test_check_cardwire_allow_returns_none_when_absent() {
+    fn test_check_env_returns_none_when_absent() {
         let environ = b"HOME=/home\0DISPLAY=:0";
-        assert_eq!(check_cardwire_allow(environ), None);
+        assert_eq!(check_env("CARDWIRE_ALLOW", environ), None);
     }
 
     #[test]
-    fn test_check_cardwire_allow_returns_none_for_empty_input() {
-        assert_eq!(check_cardwire_allow(b""), None);
+    fn test_check_env_returns_none_for_empty_input() {
+        assert_eq!(check_env("CARDWIRE_ALLOW", b""), None);
     }
 
     #[test]
-    fn test_check_cardwire_allow_returns_false_for_unexpected_value() {
+    fn test_check_env_returns_false_for_unexpected_value() {
         // "CARDWIRE_ALLOW=x" — value at index 15 is 'x', not '1'
         let environ = b"CARDWIRE_ALLOW=x";
-        assert_eq!(check_cardwire_allow(environ), Some(false));
+        assert_eq!(check_env("CARDWIRE_ALLOW", environ), Some(false));
     }
 
     /*

--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -94,20 +94,10 @@ pub fn check_env(env_var: &str, environ: &[u8]) -> Option<bool> {
 }
 
 pub fn check_gpu_env(environ: &[u8]) -> bool {
-    for var in environ.split(|&b| b == 0) {
-        if var.starts_with(b"DRI_PRIME=") {
-            if var.get(10) == Some(&b'1') {
-                return true; // DRI_PRIME=1
-            } else {
-                return false; // DRI_PRIME=0
-            }
-        } else if var.starts_with(b"__NV_PRIME_RENDER_OFFLOAD=") {
-            if var.get(26) == Some(&b'1') {
-                return true; // =1
-            } else {
-                return false; // = 0
-            }
-        }
+    if let Some(val) = check_env("DRI_PRIME", &environ) {
+        return val;
+    } else if let Some(val) = check_env("__NV_PRIME_RENDER_OFFLOAD", &environ) {
+        return val;
     }
     // Not present
     false

--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -94,9 +94,9 @@ pub fn check_env(env_var: &str, environ: &[u8]) -> Option<bool> {
 }
 
 pub fn check_gpu_env(environ: &[u8]) -> bool {
-    if let Some(val) = check_env("DRI_PRIME", &environ) {
+    if let Some(val) = check_env("DRI_PRIME", environ) {
         return val;
-    } else if let Some(val) = check_env("__NV_PRIME_RENDER_OFFLOAD", &environ) {
+    } else if let Some(val) = check_env("__NV_PRIME_RENDER_OFFLOAD", environ) {
         return val;
     }
     // Not present

--- a/crates/cardwire-daemon/src/analyzer/models.rs
+++ b/crates/cardwire-daemon/src/analyzer/models.rs
@@ -8,7 +8,7 @@ use tokio::{
 
 use crate::analyzer::{
     dynamic_analysis::{
-        check_cardwire_allow, check_cardwire_force_dgpu, check_fdo_app_id, check_for_flatpak_run, check_gamemode, check_gpu_env, check_steam_environ, get_app_id_wayland
+        check_env, check_fdo_app_id, check_for_flatpak_run, check_gamemode, check_gpu_env, check_steam_environ, get_app_id_wayland
     }, static_analysis
 };
 #[repr(C)]
@@ -189,10 +189,10 @@ impl CardwireAnalyzer {
             Err(_) => return None,
         };
         // First check CARDWIRE_ALLOW, if  None continue
-        if let Some(allow) = check_cardwire_allow(&environ) {
+        if let Some(allow) = check_env("CARDWIRE_ALLOW", &environ) {
             return Some((allow, 1));
         }
-        if let Some(value) = check_cardwire_force_dgpu(&environ) {
+        if let Some(value) = check_env("CARDWIRE_FORCE_DGPU", &environ) {
             return Some((value, 0));
         }
         let xdg_list = self.xdg_list.read().await;

--- a/crates/cardwire-daemon/src/analyzer/models.rs
+++ b/crates/cardwire-daemon/src/analyzer/models.rs
@@ -8,7 +8,7 @@ use tokio::{
 
 use crate::analyzer::{
     dynamic_analysis::{
-        check_cardwire_allow, check_fdo_app_id, check_for_flatpak_run, check_gamemode, check_gpu_env, check_steam_environ, get_app_id_wayland
+        check_cardwire_allow, check_cardwire_force_dgpu, check_fdo_app_id, check_for_flatpak_run, check_gamemode, check_gpu_env, check_steam_environ, get_app_id_wayland
     }, static_analysis
 };
 #[repr(C)]
@@ -155,16 +155,20 @@ impl CardwireAnalyzer {
             None => return,
         };
         if let Some(result) = self.evaluate_app(event.pid, &real_app_name).await
-            && result
+            && result.0
         {
-            info!(
-                "ALLOW: pid: {} process: {} in {}us",
-                event.pid,
-                &real_app_name,
-                time.elapsed().as_micros()
-            );
+            match result.1 {
+                0 => info!("FORCE: pid: {} process: {} ", event.pid, &real_app_name),
+                1 => info!(
+                    "ALLOW: pid: {} process: {} in {}us",
+                    event.pid,
+                    &real_app_name,
+                    time.elapsed().as_micros()
+                ),
+                _ => {}
+            }
             let mut pid_map = self.pid_map.write().await;
-            if let Err(e) = pid_map.insert(event.pid, 1, 0) {
+            if let Err(e) = pid_map.insert(event.pid, result.1, 0) {
                 warn!("Failed to insert into eBPF map: {}", e);
             }
         }
@@ -176,8 +180,9 @@ impl CardwireAnalyzer {
         }
     }
 
-    /// Default app are blocked, try to find if it's a game or a gpu intensive app
-    async fn evaluate_app(&self, pid: u32, comm: &str) -> Option<bool> {
+    /// Default app are blocked, try to find if it's a game or a gpu intensive app, the u8 is the
+    /// gpu id
+    async fn evaluate_app(&self, pid: u32, comm: &str) -> Option<(bool, u8)> {
         let path = format!("/proc/{}/environ", pid);
         let environ = match fs::read(path) {
             Ok(content) => content,
@@ -185,7 +190,10 @@ impl CardwireAnalyzer {
         };
         // First check CARDWIRE_ALLOW, if  None continue
         if let Some(allow) = check_cardwire_allow(&environ) {
-            return Some(allow);
+            return Some((allow, 1));
+        }
+        if let Some(value) = check_cardwire_force_dgpu(&environ) {
+            return Some((value, 0));
         }
         let xdg_list = self.xdg_list.read().await;
 
@@ -211,7 +219,7 @@ impl CardwireAnalyzer {
             };
             result = check_gamemode(&map);
         }
-        Some(result)
+        Some((result, 1))
     }
 
     #[allow(dead_code)]

--- a/crates/cardwire-daemon/src/interface/debug.rs
+++ b/crates/cardwire-daemon/src/interface/debug.rs
@@ -146,7 +146,7 @@ impl DebugInterface {
                         "GPU {} should be blocked, re-applying block on hotplug",
                         gpu.device.name()
                     );
-                    if let Err(e) = gpu.block_gpu().await {
+                    if let Err(e) = gpu.block_gpu(1).await {
                         warn!(
                             "failed to automatically re-block {}: {}",
                             gpu.device.name(),

--- a/crates/cardwire-daemon/src/interface/gpu.rs
+++ b/crates/cardwire-daemon/src/interface/gpu.rs
@@ -55,20 +55,20 @@ impl GpuInterface {
 }
 
 impl GpuInterface {
-    /// block the gpu
-    pub async fn block_gpu(&mut self) -> fdo::Result<()> {
+    /// block the gpu, 1 = dGPU, 0 = iGPU
+    pub async fn block_gpu(&mut self, value: u8) -> fdo::Result<()> {
         let mut blocker = self.blocker.write().await;
         let pci_list = self.pci_list.read().await;
         // First block the card id
         match card_to_inode(*self.device.card()) {
-            Ok(inode) => blocker.block_inode(inode).into_fdo()?,
+            Ok(inode) => blocker.block_inode(inode, value).into_fdo()?,
             Err(err) => {
                 error!("failed to block card{}: {}", *self.device.card(), err);
                 return Err(err).into_fdo();
             }
         };
         match render_to_inode(*self.device.render()) {
-            Ok(inode) => blocker.block_inode(inode).into_fdo()?,
+            Ok(inode) => blocker.block_inode(inode, value).into_fdo()?,
             Err(err) => {
                 error!("failed to block render{}: {}", *self.device.render(), err);
                 return Err(err).into_fdo();
@@ -81,7 +81,7 @@ impl GpuInterface {
         ) {
             Ok(inodes) => {
                 for inode in inodes {
-                    if let Err(err) = blocker.block_inode(inode) {
+                    if let Err(err) = blocker.block_inode(inode, value) {
                         error!("failed to block inode(pci) {}: {}", inode, err);
                         return Err(err).into_fdo();
                     }
@@ -100,7 +100,7 @@ impl GpuInterface {
         match sys_drm_inodes(*self.device.render(), *self.device.card()) {
             Ok(inodes) => {
                 for inode in inodes {
-                    if let Err(err) = blocker.block_inode(inode) {
+                    if let Err(err) = blocker.block_inode(inode, value) {
                         error!("failed to block inode(drm) {}: {}", inode, err);
                         return Err(err).into_fdo();
                     }
@@ -120,14 +120,14 @@ impl GpuInterface {
             && let Some(minor) = self.device.nvidia_minor()
         {
             match nvidia_to_inode(*minor) {
-                Ok(inode) => blocker.block_inode(inode).into_fdo()?,
+                Ok(inode) => blocker.block_inode(inode, value).into_fdo()?,
                 Err(err) => {
                     error!("failed to block nvidia{}: {}", *self.device.render(), err);
                     return Err(err).into_fdo();
                 }
             };
             match backlight_to_inode(*minor) {
-                Ok(inode) => blocker.block_inode(inode).into_fdo()?,
+                Ok(inode) => blocker.block_inode(inode, value).into_fdo()?,
                 Err(err) => {
                     error!(
                         "(ignoring) failed to block backlight nvidia_{}: {}",
@@ -291,7 +291,7 @@ impl GpuInterface {
                 )));
             }
             // Now block
-            self.block_gpu().await?;
+            self.block_gpu(1).await?;
             info!("Set GPU {} block={}", self.device.name(), block);
             // save new state to file
             let mut gpu_state = self.gpu_state.write().await;

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -125,11 +125,18 @@ impl ModeInterface {
                 for gpu in gpu_list.values_mut() {
                     if !gpu.device.is_default() {
                         if mode == Modes::Integrated || mode == Modes::Smart {
-                            gpu.block_gpu().await?;
+                            // Here we block the dGPU
+                            gpu.block_gpu(1).await?;
                         } else {
                             gpu.unblock_gpu().await?;
                         }
                     };
+
+                    // If we in smart mode and is the default gpu, push it to the blocked inode map
+                    // but it wont get blocked, trust
+                    if mode == Modes::Smart && gpu.device.is_default() {
+                        gpu.block_gpu(0).await?;
+                    }
                 }
             }
 
@@ -152,7 +159,7 @@ impl ModeInterface {
                             gpu.unblock_gpu().await?;
                         } else {
                             info!("blocking: {} ", gpu.device.pci().pci_address());
-                            gpu.block_gpu().await?;
+                            gpu.block_gpu(1).await?;
                         }
                     } else {
                         gpu.unblock_gpu().await?;

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -130,12 +130,12 @@ impl ModeInterface {
                         } else {
                             gpu.unblock_gpu().await?;
                         }
-                    };
-
-                    // If we in smart mode and is the default gpu, push it to the blocked inode map
-                    // but it wont get blocked, trust
-                    if mode == Modes::Smart && gpu.device.is_default() {
+                    } else if mode == Modes::Smart {
+                        // push default gpu (iGPU) into the blocked inode map for tracking only
                         gpu.block_gpu(0).await?;
+                    } else {
+                        // clear
+                        gpu.unblock_gpu().await?;
                     }
                 }
             }

--- a/crates/cardwire-ebpf/src/c/bpf.c
+++ b/crates/cardwire-ebpf/src/c/bpf.c
@@ -149,8 +149,16 @@ int cardwire_sys_enter_getdents64(struct trace_event_raw_sys_enter *ctx)
 	// if we in smart mode and the pid is allowed, skip
 	if (is_smart()) {
 		if (is_pid_allowed(pid, ppid)) {
-			// if allowed, skip
-			return 0;
+			__u8 *allow_val =
+				bpf_map_lookup_elem(&cw_allowed_pid, &pid);
+			if (!allow_val) {
+				allow_val = bpf_map_lookup_elem(&cw_allowed_pid,
+								&ppid);
+			}
+			// If force_dgpu is NOT enabled, we can safely skip patching
+			if (allow_val && *allow_val != 0) {
+				return 0;
+			}
 		}
 	}
 
@@ -185,8 +193,16 @@ int cardwire_sys_exit_getdents64(struct trace_event_raw_sys_exit *ctx)
 	// if we in smart mode and the pid is allowed, skip
 	if (is_smart()) {
 		if (is_pid_allowed(pid, ppid)) {
-			// if allowed, skip
-			return 0;
+			__u8 *allow_val =
+				bpf_map_lookup_elem(&cw_allowed_pid, &pid);
+			if (!allow_val) {
+				allow_val = bpf_map_lookup_elem(&cw_allowed_pid,
+								&ppid);
+			}
+			// If force_dgpu is NOT enabled, we can safely skip patching
+			if (allow_val && *allow_val != 0) {
+				return 0;
+			}
 		}
 	}
 

--- a/crates/cardwire-ebpf/src/c/helpers.h
+++ b/crates/cardwire-ebpf/src/c/helpers.h
@@ -89,12 +89,15 @@ static __always_inline int is_blocked_device(struct dentry *d)
 	bool blocked = false;
 
 	struct inode *inode = BPF_CORE_READ(d, d_inode);
+	__u8 *map_val = 0;
 	// Match card/render/nvidia minor
 	if (inode) {
 		__u64 d_ino = BPF_CORE_READ(inode, i_ino);
 		if (d_ino) {
-			// if it's a blocked inode, go to end
-			if (bpf_map_lookup_elem(&cw_blocked_ino, &d_ino)) {
+			map_val = bpf_map_lookup_elem(&cw_blocked_ino, &d_ino);
+			// if inode is in the map, blocked
+			// we store the value to identify the dGPU/iGPU
+			if (map_val) {
 				blocked = true;
 				goto end;
 			}
@@ -126,6 +129,25 @@ end:
 
 	// if smart, check the pid list
 	if (*mode == 3) {
+		// Check if the inode is linked to the iGPU
+		if (map_val && *map_val == 0) {
+			__u8 *allow_map_value =
+				bpf_map_lookup_elem(&cw_allowed_pid, &pid);
+			if (!allow_map_value) {
+				allow_map_value = bpf_map_lookup_elem(
+					&cw_allowed_pid, &ppid);
+			}
+			// IF the inode is linked to a iGPU and the map_key exist
+			if (allow_map_value) {
+				// This mean the inode is allowed, but to check if we should force the dGPU or not,value should be at 0
+				if (*allow_map_value == 0) {
+					// We should hide the iGPU
+					return -ENOENT;
+				}
+			}
+			return 0;
+		}
+
 		if (!bpf_map_lookup_elem(&cw_allowed_pid, &pid) &&
 		    !bpf_map_lookup_elem(&cw_allowed_pid, &ppid)) {
 			// Neither pid nor ppid is allowed, block and report the event
@@ -178,9 +200,9 @@ static __always_inline int patch_dirent_if_found(__u32 _,
 	bpf_probe_read_user_str(dirname, sizeof(dirname), dirent->d_name);
 
 	// Check if this is a file we want to hide
-	if (bpf_map_lookup_elem(&cw_blocked_ino, &d_inode) ||
-	    (is_nvidia_enabled() &&
-	     bpf_map_lookup_elem(&cw_exp_blk_ino, &d_inode))) {
+	__u8 *map_val = bpf_map_lookup_elem(&cw_blocked_ino, &d_inode);
+	if (map_val || (is_nvidia_enabled() &&
+			bpf_map_lookup_elem(&cw_exp_blk_ino, &d_inode))) {
 		if (data->last_visible_bpos != 0xFFFFFFFF) {
 			struct linux_dirent64 *visible_dirent =
 				(struct linux_dirent64
@@ -191,12 +213,51 @@ static __always_inline int patch_dirent_if_found(__u32 _,
 				       &visible_dirent->d_reclen);
 
 			__u16 new_reclen = visible_reclen + data->d_reclen;
+			// check for iGPU
+			if (is_smart()) {
+				__u32 pid = bpf_get_current_pid_tgid() >> 32;
+				struct task_struct *task =
+					(struct task_struct *)
+						bpf_get_current_task();
+				__u32 ppid =
+					BPF_CORE_READ(task, real_parent, tgid);
 
+				__u8 *allow_map_value = bpf_map_lookup_elem(
+					&cw_allowed_pid, &pid);
+
+				if (map_val && *map_val == 0) {
+					// It's the iGPU
+					if (allow_map_value) {
+						// map is valid and value isn't 1 (dGPU)
+						if (*allow_map_value != 1) {
+							// force dGPU is active: hide the iGPU
+							bpf_probe_write_user(
+								&visible_dirent
+									 ->d_reclen,
+								&new_reclen,
+								sizeof(new_reclen));
+							goto end;
+						} else {
+							// allowed process, no force: show iGPU
+							goto not_hidden;
+						}
+					} else {
+						goto not_hidden;
+					}
+				} else {
+					// It's the dGPU
+					if (allow_map_value) {
+						// Allowed process: must see the dGPU!
+						goto not_hidden;
+					}
+					// Unallowed process: fall through to hide the dGPU
+				}
+			}
 			// Overwrite the visible file's length so it skips over the hidden file
 			bpf_probe_write_user(&visible_dirent->d_reclen,
 					     &new_reclen, sizeof(new_reclen));
 		}
-
+end:
 		data->bpos += data->d_reclen;
 		// Reserve space, return if it fails
 		struct report_t *rb_report = bpf_ringbuf_reserve(
@@ -212,6 +273,7 @@ static __always_inline int patch_dirent_if_found(__u32 _,
 		return 0; // Continue loop
 	}
 
+not_hidden:
 	// Not a hidden file, update last_visible_bpos and advance
 	data->last_visible_bpos = data->bpos;
 	data->bpos += data->d_reclen;

--- a/crates/cardwire-ebpf/src/c/helpers.h
+++ b/crates/cardwire-ebpf/src/c/helpers.h
@@ -136,14 +136,14 @@ end:
 				bpf_map_lookup_elem(&cw_allowed_pid, &pid);
 
 			// if the isn't in the map, check the ppid
-			if (!allow_map_value) {
-				allow_map_value = bpf_map_lookup_elem(
+			if (!allow_map_value_pid) {
+				allow_map_value_pid = bpf_map_lookup_elem(
 					&cw_allowed_pid, &ppid);
 			}
 			// IF the inode is linked to a iGPU and the map_key exist
-			if (allow_map_value) {
+			if (allow_map_value_pid) {
 				// This mean the inode is allowed, but to check if we should force the dGPU or not,value should be at 0
-				if (*allow_map_value == 0) {
+				if (*allow_map_value_pid == 0) {
 					// We should hide the iGPU
 					return -ENOENT;
 				}

--- a/crates/cardwire-ebpf/src/c/helpers.h
+++ b/crates/cardwire-ebpf/src/c/helpers.h
@@ -131,8 +131,11 @@ end:
 	if (*mode == 3) {
 		// Check if the inode is linked to the iGPU
 		if (map_val && *map_val == 0) {
-			__u8 *allow_map_value =
+			// Check if the PID is in the map
+			__u8 *allow_map_value_pid =
 				bpf_map_lookup_elem(&cw_allowed_pid, &pid);
+
+			// if the isn't in the map, check the ppid
 			if (!allow_map_value) {
 				allow_map_value = bpf_map_lookup_elem(
 					&cw_allowed_pid, &ppid);
@@ -215,6 +218,7 @@ static __always_inline int patch_dirent_if_found(__u32 _,
 			__u16 new_reclen = visible_reclen + data->d_reclen;
 			// check for iGPU
 			if (is_smart()) {
+				// Get the process pid and ppid
 				__u32 pid = bpf_get_current_pid_tgid() >> 32;
 				struct task_struct *task =
 					(struct task_struct *)
@@ -222,13 +226,19 @@ static __always_inline int patch_dirent_if_found(__u32 _,
 				__u32 ppid =
 					BPF_CORE_READ(task, real_parent, tgid);
 
+				// Read the map to check if the pid is present
 				__u8 *allow_map_value = bpf_map_lookup_elem(
 					&cw_allowed_pid, &pid);
-
+				// if pid is not present, try with ppid
+				if (!allow_map_value) {
+					allow_map_value = bpf_map_lookup_elem(
+						&cw_allowed_pid, &ppid);
+				}
+				// check if it's an inode linked to the iGPU
 				if (map_val && *map_val == 0) {
 					// It's the iGPU
 					if (allow_map_value) {
-						// map is valid and value isn't 1 (dGPU)
+						// PID exist and value isn't 1 (dGPU)
 						if (*allow_map_value != 1) {
 							// force dGPU is active: hide the iGPU
 							bpf_probe_write_user(

--- a/crates/cardwire-ebpf/src/lib.rs
+++ b/crates/cardwire-ebpf/src/lib.rs
@@ -116,7 +116,8 @@ impl EbpfBlocker {
         }
     }
 
-    pub fn block_inode(&mut self, inode: u64) -> CardwireEbpfResult<()> {
+    /// Block an inode, value should be a either 0(iGPU) or 1 (dGPU)
+    pub fn block_inode(&mut self, inode: u64, value: u8) -> CardwireEbpfResult<()> {
         // Also insert hardcoded values for now
         let mut inode_map: HashMap<_, u64, u8> = HashMap::try_from(
             self.ebpf
@@ -125,7 +126,7 @@ impl EbpfBlocker {
         )
         .map_err(CardwireEbpfError::aya)?;
         inode_map
-            .insert(inode, 1, 0)
+            .insert(inode, value, 0)
             .map_err(CardwireEbpfError::aya)?;
         Ok(())
     }
@@ -155,7 +156,9 @@ impl EbpfBlocker {
         )
         .map_err(CardwireEbpfError::aya)?;
         match inode_map.get(&inode, 0) {
-            Ok(_) => Ok(true),
+            // 1 = dGPU, 0 = iGPU, if the inode is in the map it means the dGPU is meant to be
+            // blocked so true
+            Ok(value) => Ok(value == 1),
             Err(MapError::KeyNotFound) => Ok(false),
             Err(err) => Err(CardwireEbpfError::aya(err)),
         }


### PR DESCRIPTION
# Description

Add a new ENV var named `CARWIRE_FORCE_DGPU`, setting this env to 1 before launching a process would hide the iGPU from the process, if the program only sees the dGPU, it should always select it

This is only for smart mode, porting to manual mode would be a task for >0.12.0 and would require rewriting some parts of the ebpf code, i'm also considering rewriting it to rust.

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added environment-variable support to detect a “force dGPU” preference.
  * Improved smart-mode GPU behavior to make visibility/blocking decisions per process.

* **Bug Fixes**
  * Updated GPU blocking/unblocking to use explicit GPU identifiers and propagate the selected mode consistently.
  * Refined smart-mode short-circuit and allow-list handling so skips/hiding only occur when process permission data is present and nonzero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->