### PR TITLE
fix(cardwired): add manual mode fallback if apply mode at startup fails

### DIFF
--- a/crates/cardwire-daemon/src/models.rs
+++ b/crates/cardwire-daemon/src/models.rs
@@ -131,7 +131,15 @@ impl DaemonManager {
         // If it's the first time cardwired is launched, we need to populate the gpu state file
         self.populate_state_file().await?;
 
-        self.apply_mode_at_startup().await?;
+        // This one can fail on asus laptop when switching to integrated using the kernel attribute
+        if let Err(err) = self.apply_mode_at_startup(None).await {
+            error!(
+                "failed to apply mode at startup: {}, switching to manual...",
+                err
+            );
+            // 2 = manual
+            self.apply_mode_at_startup(Some(2)).await?
+        };
 
         Ok(())
     }
@@ -210,10 +218,14 @@ impl DaemonManager {
         }
         Ok(())
     }
-    async fn apply_mode_at_startup(&self) -> Result<()> {
-        let mode_to_apply = {
-            let mode = self.inner.mode_state.read().await;
-            Modes::into(mode.mode())
+    async fn apply_mode_at_startup(&self, mode: Option<u32>) -> Result<()> {
+        // If a mode is supplied as arg, use it, else read the internal state (from file)
+        let mode_to_apply = match mode {
+            Some(mode) => mode,
+            None => {
+                let mode = self.inner.mode_state.read().await;
+                Modes::into(mode.mode())
+            }
         };
         self.mode_interface
             .set_mode(mode_to_apply)

--- a/crates/cardwire-daemon/src/models.rs
+++ b/crates/cardwire-daemon/src/models.rs
@@ -218,19 +218,27 @@ impl DaemonManager {
         }
         Ok(())
     }
-    async fn apply_mode_at_startup(&self, mode: Option<u32>) -> Result<()> {
+    async fn apply_mode_at_startup(&self, mode_arg: Option<u32>) -> Result<()> {
         // If a mode is supplied as arg, use it, else read the internal state (from file)
-        let mode_to_apply = match mode {
+        let mut mode_lock = self.inner.mode_state.write().await;
+        let mode_to_apply = match mode_arg {
             Some(mode) => mode,
-            None => {
-                let mode = self.inner.mode_state.read().await;
-                Modes::into(mode.mode())
-            }
+            None => Modes::into(mode_lock.mode()),
         };
-        self.mode_interface
+        // store the result to return it later
+        let res = self
+            .mode_interface
             .set_mode(mode_to_apply)
             .await
-            .map_err(|err| err.into())
+            .map_err(|err| err.into());
+        // If a mode was supplied as arg and we can convert u32 -> Modes, we bring back the user
+        // configured mode
+        if mode_arg.is_some()
+            && let Ok(mode_var) = Modes::try_from(mode_to_apply)
+        {
+            mode_lock.save_state(mode_var).await?;
+        }
+        res
     }
     pub fn battery_switch_future(&self) -> impl Future<Output = Result<(), zbus::Error>> + 'static {
         let auto_switch = Arc::clone(&self.inner.config.battery_auto_switch);


### PR DESCRIPTION
# Description

Fixes an issue on asus laptop where switching to hardware integrated mode would fail the daemon on startup

Fixes # (issue)

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup resilience when applying the configured mode fails.
  * The system now logs the failure and retries using manual mode to complete initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->