### PR TITLE
fix(cardwired): block vulkan files instead of the whole folder

### DIFF
--- a/crates/cardwire-daemon/src/core/inode.rs
+++ b/crates/cardwire-daemon/src/core/inode.rs
@@ -145,10 +145,10 @@ pub fn exp_nvidia_inodes() -> Result<Vec<u64>> {
         for entry in entries.flatten() {
             let name = entry.file_name();
 
-            if name == "nvidia_icd.json" || name == "nvidia_icd.x86_64.json" {
-                if let Ok(metadata) = fs::metadata(entry.path()) {
-                    inodes.push(metadata.ino());
-                }
+            if (name == "nvidia_icd.json" || name == "nvidia_icd.x86_64.json")
+                && let Ok(metadata) = fs::metadata(entry.path())
+            {
+                inodes.push(metadata.ino());
             }
         }
     }

--- a/crates/cardwire-daemon/src/core/inode.rs
+++ b/crates/cardwire-daemon/src/core/inode.rs
@@ -149,6 +149,7 @@ pub fn exp_nvidia_inodes() -> Result<Vec<u64>> {
                 || name == "nvidia_icd.x86_64.json"
                 || name == "nvidia_icd.i686.json")
                 && let Ok(metadata) = fs::metadata(entry.path())
+                && metadata.is_file()
             {
                 inodes.push(metadata.ino());
             }

--- a/crates/cardwire-daemon/src/core/inode.rs
+++ b/crates/cardwire-daemon/src/core/inode.rs
@@ -145,7 +145,9 @@ pub fn exp_nvidia_inodes() -> Result<Vec<u64>> {
         for entry in entries.flatten() {
             let name = entry.file_name();
 
-            if (name == "nvidia_icd.json" || name == "nvidia_icd.x86_64.json")
+            if (name == "nvidia_icd.json"
+                || name == "nvidia_icd.x86_64.json"
+                || name == "nvidia_icd.i686.json")
                 && let Ok(metadata) = fs::metadata(entry.path())
             {
                 inodes.push(metadata.ino());

--- a/crates/cardwire-daemon/src/core/inode.rs
+++ b/crates/cardwire-daemon/src/core/inode.rs
@@ -138,17 +138,18 @@ pub fn exp_nvidia_inodes() -> Result<Vec<u64>> {
     ];
 
     for path in VULKAN_PATHS {
-        let has_nvidia = fs::read_dir(path)
-            .map(|entries| {
-                entries.filter_map(|e| e.ok()).any(|entry| {
-                    let name = entry.file_name();
-                    name == "nvidia_icd.json" || name == "nvidia_icd.x86_64.json"
-                })
-            })
-            .unwrap_or(false);
+        let Ok(entries) = fs::read_dir(path) else {
+            continue;
+        };
 
-        if has_nvidia && let Ok(metadata) = fs::metadata(path) {
-            inodes.push(metadata.ino());
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+
+            if name == "nvidia_icd.json" || name == "nvidia_icd.x86_64.json" {
+                if let Ok(metadata) = fs::metadata(entry.path()) {
+                    inodes.push(metadata.ino());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and if applicable, a related issue.

If this PR introduce a new feature, explain your motivations

Fixes # (issue)

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NVIDIA Vulkan driver discovery to identify matching ICD files accurately.
  * Improved handling when multiple driver configuration files are present.
  * Added more resilient behavior by safely skipping unreadable directories and entries during driver discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->