### PR TITLE
feat(cardwired): only restart nvidia-powerd if the service is enabled

### DIFF
--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -103,25 +103,45 @@ impl ModeInterface {
     async fn restart_nvidia_powerd() {
         let service = "nvidia-powerd.service";
 
-        match Command::new("systemctl")
-            .arg("restart")
+        let enabled = match Command::new("systemctl")
+            .arg("is-enabled")
             .arg(service)
-            .arg("--no-block")
-            .stdout(Stdio::null())
-            .status()
+            .output()
             .await
         {
-            Ok(status) => {
-                if status.success() {
-                    info!("successfully restart nvidia-powerd.service");
+            Ok(output) => {
+                if let Ok(output_str) = str::from_utf8(&output.stdout) {
+                    output_str.contains("enabled")
                 } else {
-                    warn!("error restarting nvidia-powerd: {:?}", status.code())
+                    false
                 }
             }
             Err(err) => {
-                error!("error while trying to restart nvidia-powerd: {}", err)
+                error!("error while trying to detect nvidia-powerd: {}", err);
+                return;
             }
         };
+        if enabled {
+            match Command::new("systemctl")
+                .arg("restart")
+                .arg(service)
+                .arg("--no-block")
+                .stdout(Stdio::null())
+                .status()
+                .await
+            {
+                Ok(status) => {
+                    if status.success() {
+                        info!("successfully restart nvidia-powerd.service");
+                    } else {
+                        warn!("error restarting nvidia-powerd: {:?}", status.code())
+                    }
+                }
+                Err(err) => {
+                    error!("error while trying to restart nvidia-powerd: {}", err)
+                }
+            };
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and if applicable, a related issue.

If this PR introduce a new feature, explain your motivations

Fixes # (issue)

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA power service handling by restarting it only when enabled.
  * Added safer behavior when service detection fails or the service is disabled.
  * Improved status and restart error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->