### PR TITLE
feat: add metainfo.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	install -Dm0644 assets/cardwired.service /usr/lib/systemd/system/cardwired.service
 	install -Dm0644 assets/com.github.opengamingcollective.cardwire.conf /usr/share/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf
 	install -Dm0644 assets/cardwire-gui.desktop /usr/share/applications/cardwire-gui.desktop
-	install -Dm-655 assets/com.github.opengamingcollective.cardwire.metainfo.xml /usr/share/metainfo/com.github.opengamingcollective.cardwire.metainfo.xml
+	install -Dm0644 assets/com.github.opengamingcollective.cardwire.metainfo.xml /usr/share/metainfo/com.github.opengamingcollective.cardwire.metainfo.xml
 	for icon in assets/icons/*.svg; do install -Dm0644 "$$icon" "/usr/share/icons/hicolor/scalable/apps/$$(basename "$$icon")"; done
 	systemctl enable cardwired.service
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ install:
 	install -Dm0644 assets/cardwired.service /usr/lib/systemd/system/cardwired.service
 	install -Dm0644 assets/com.github.opengamingcollective.cardwire.conf /usr/share/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf
 	install -Dm0644 assets/cardwire-gui.desktop /usr/share/applications/cardwire-gui.desktop
+	install -Dm-655 assets/com.github.opengamingcollective.cardwire.metainfo.xml /usr/share/metainfo/com.github.opengamingcollective.cardwire.metainfo.xml
 	for icon in assets/icons/*.svg; do install -Dm0644 "$$icon" "/usr/share/icons/hicolor/scalable/apps/$$(basename "$$icon")"; done
 	systemctl enable cardwired.service
 

--- a/assets/com.github.opengamingcollective.cardwire.metainfo.xml
+++ b/assets/com.github.opengamingcollective.cardwire.metainfo.xml
@@ -32,6 +32,7 @@
     <keyword>eBPF LSM</keyword>
     <keyword>asusctl</keyword>
     <keyword>switcheroo-control</keyword>
+    <keyword>supergfxctl</keyword>
   </keywords>
 
   <releases>

--- a/assets/com.github.opengamingcollective.cardwire.metainfo.xml
+++ b/assets/com.github.opengamingcollective.cardwire.metainfo.xml
@@ -6,7 +6,7 @@
   <!-- Temporary until we have an icon -->
   <icon type="local">/usr/share/icons/hicolor/scalable/apps/com.github.opengamingcollective.cardwire.tray.svg</icon>
 
-  <name>cardwire-gui</name>
+  <name>Cardwire</name>
   <summary>A GPU Manager for linux that uses eBPF LSM hooks to block GPUs</summary>
 
   <!-- <screenshots>

--- a/assets/com.github.opengamingcollective.cardwire.metainfo.xml
+++ b/assets/com.github.opengamingcollective.cardwire.metainfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>com.github.opengamingcollective.cardwire</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <!-- Temporary until we have an icon -->
+  <icon type="local">/usr/share/icons/hicolor/scalable/apps/com.github.opengamingcollective.cardwire.tray.svg</icon>
+
+  <name>cardwire-gui</name>
+  <summary>A GPU Manager for linux that uses eBPF LSM hooks to block GPUs</summary>
+
+  <!-- <screenshots>
+    <screenshot type="default"><image>PLACEHOLDER</image></screenshot>
+  </screenshots> -->
+
+  <description>
+    <p>
+        cardwire GUI is a GPU manager for Linux using eBPF LSM hooks to block GPUs.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">cardwire-gui.desktop</launchable>
+
+  <url type="homepage">https://github.com/OpenGamingCollective/cardwire</url>
+  <provides>
+    <binary>cardwire-gui</binary>
+  </provides>
+
+  <keywords>
+    <keyword>GPU</keyword>
+    <keyword>GPU manager</keyword>
+    <keyword>eBPF LSM</keyword>
+    <keyword>asusctl</keyword>
+    <keyword>switcheroo-control</keyword>
+  </keywords>
+
+  <releases>
+    <release version="0.11.1" />
+  </releases>
+</component>

--- a/crates/cardwire-daemon/Cargo.toml
+++ b/crates/cardwire-daemon/Cargo.toml
@@ -47,6 +47,7 @@ assets = [
     ["../../assets/99-cardwired.preset", "usr/lib/systemd/system-preset/", "644"],
     ["../../assets/com.github.opengamingcollective.cardwire.conf", "usr/share/dbus-1/system.d/", "644"],
     ["../../assets/cardwire-gui.desktop", "usr/share/applications/", "644"],
+    ["../../assets/com.github.opengamingcollective.cardwire.metainfo.xml", "usr/share/metainfo/", "644"],
     ["../../assets/icons/com.github.opengamingcollective.cardwire.tray.svg", "usr/share/icons/hicolor/scalable/apps/", "644"],
     ["../../assets/icons/com.github.opengamingcollective.cardwire.tray-integrated.svg", "usr/share/icons/hicolor/scalable/apps/", "644"],
     ["../../assets/icons/com.github.opengamingcollective.cardwire.tray-hybrid.svg", "usr/share/icons/hicolor/scalable/apps/", "644"],

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -58,6 +58,9 @@ in
       install -Dm444 ./assets/cardwire-gui.desktop \
          $out/share/applications/cardwire-gui.desktop
 
+      install -Dm444 ./assets/com.github.opengamingcollective.cardwire.metainfo.xml \
+	 $out/share/metainfo/com.github.opengamingcollective.cardwire.metainfo.xml
+
       for icon in ./assets/icons/*.svg; do
         install -Dm444 "$icon" "$out/share/icons/hicolor/scalable/apps/$(basename "$icon")"
       done

--- a/packages/arch-linux/cardwire-PKGBUILD
+++ b/packages/arch-linux/cardwire-PKGBUILD
@@ -36,6 +36,7 @@ package(){
 	install -Dm644 assets/cardwired.service "$pkgdir/usr/lib/systemd/system/cardwired.service"
 	install -Dm644 assets/com.github.opengamingcollective.cardwire.conf "$pkgdir/usr/share/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf"
 	install -Dm644 assets/cardwire-gui.desktop "$pkgdir/usr/share/applications/cardwire-gui.desktop"
+	install -Dm644 assets/com.github.opengamingcollective.cardwire.metainfo.xml "$pkgdir/usr/share/metainfo/com.github.opengamingcollective.cardwire.metainfo.xml
 	for icon in assets/icons/*.svg; do
 		install -Dm644 "$icon" "$pkgdir/usr/share/icons/hicolor/scalable/apps/$(basename "$icon")"
 	done

--- a/packages/arch-linux/cardwire-PKGBUILD
+++ b/packages/arch-linux/cardwire-PKGBUILD
@@ -36,7 +36,7 @@ package(){
 	install -Dm644 assets/cardwired.service "$pkgdir/usr/lib/systemd/system/cardwired.service"
 	install -Dm644 assets/com.github.opengamingcollective.cardwire.conf "$pkgdir/usr/share/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf"
 	install -Dm644 assets/cardwire-gui.desktop "$pkgdir/usr/share/applications/cardwire-gui.desktop"
-	install -Dm644 assets/com.github.opengamingcollective.cardwire.metainfo.xml "$pkgdir/usr/share/metainfo/com.github.opengamingcollective.cardwire.metainfo.xml
+	install -Dm644 assets/com.github.opengamingcollective.cardwire.metainfo.xml "$pkgdir/usr/share/metainfo/com.github.opengamingcollective.cardwire.metainfo.xml"
 	for icon in assets/icons/*.svg; do
 		install -Dm644 "$icon" "$pkgdir/usr/share/icons/hicolor/scalable/apps/$(basename "$icon")"
 	done


### PR DESCRIPTION
# Description

Adds a metainfo.xml file for packaging, changes PKGBUILD, nix, and Cargo.toml files appropriately.

# TODO

- [ ] We currently have placeholder screenshots and icons. I'd like to at least have a screenshot before merge, as the icon uses the current cardwire tray icon.

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop application metadata, including the app description, licensing, homepage, icon, keywords, and launch information.
  * Added version 0.11.1 information for improved application discovery and presentation in software centers.
* **Packaging**
  * Included the application metadata in Makefile, Debian, Nix, and Arch Linux installations.
  * Packaged installations now provide standardized AppStream information for supported desktop environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->