### PR TITLE
feat(cardwired): default to hybrid mode instead of manual

### DIFF
--- a/crates/cardwire-daemon/src/file/state.rs
+++ b/crates/cardwire-daemon/src/file/state.rs
@@ -17,7 +17,7 @@ pub struct CardwireModeState {
 impl Default for CardwireModeState {
     fn default() -> Self {
         CardwireModeState {
-            mode: Modes::Manual,
+            mode: Modes::Hybrid,
         }
     }
 }
@@ -153,9 +153,9 @@ mod tests {
     */
 
     #[test]
-    fn test_mode_state_default_is_manual() {
+    fn test_mode_state_default_is_hybrid() {
         let state = CardwireModeState::default();
-        assert_eq!(state.mode(), Modes::Manual);
+        assert_eq!(state.mode(), Modes::Hybrid);
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
     fn test_mode_state_json_parse_empty_uses_defaults() {
         let json = "{}";
         let parsed: CardwireModeState = serde_json::from_str(json).unwrap();
-        assert_eq!(parsed.mode(), Modes::Manual);
+        assert_eq!(parsed.mode(), Modes::Hybrid);
     }
 
     /*

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -17,8 +17,8 @@ use zbus::{fdo, interface, object_server::InterfaceRef};
 #[serde(rename_all = "snake_case")]
 pub enum Modes {
     Integrated,
-    Hybrid,
     #[default]
+    Hybrid,
     Manual,
     Smart,
 }
@@ -483,8 +483,8 @@ mod tests {
     }
 
     #[test]
-    fn test_modes_default_is_manual() {
-        assert_eq!(Modes::default(), Modes::Manual);
+    fn test_modes_default_is_hybrid() {
+        assert_eq!(Modes::default(), Modes::Hybrid);
     }
 
     #[test]


### PR DESCRIPTION
# Description

Change the default mode from manual to hybrid for new installations

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
