### PR TITLE
feat(daemon): expose external display auto-switch setting

### DIFF
--- a/crates/cardwire-daemon/src/interface/config.rs
+++ b/crates/cardwire-daemon/src/interface/config.rs
@@ -81,6 +81,13 @@ impl ConfigInterface {
         let mode = self.config.battery_auto_switch_mode.load(Ordering::Relaxed);
         Ok(mode)
     }
+    #[zbus(property)]
+    pub async fn external_display_auto_switch(&self) -> fdo::Result<bool> {
+        Ok(self
+            .config
+            .external_display_auto_switch
+            .load(Ordering::Relaxed))
+    }
 
     // setters
     #[zbus(property)]
@@ -120,6 +127,14 @@ impl ConfigInterface {
         self.config
             .battery_auto_switch_mode
             .store(mode, Ordering::Relaxed);
+        self.save_to_file().await?;
+        Ok(())
+    }
+    #[zbus(property)]
+    pub async fn set_external_display_auto_switch(&mut self, state: bool) -> fdo::Result<()> {
+        self.config
+            .external_display_auto_switch
+            .store(state, Ordering::Relaxed);
         self.save_to_file().await?;
         Ok(())
     }

--- a/docs/development/dbus.md
+++ b/docs/development/dbus.md
@@ -73,10 +73,9 @@
   - **Access:** Read/Write
 
 - **`ExternalDisplayAutoSwitch`**
-  Makes the required GPU available when an external display is connected to a dGPU-owned DRM
-  connector. Manual mode remains active and temporarily unblocks that GPU; other modes switch to
-  Hybrid. The previous mode and GPU state are restored after disconnect unless explicitly
-  overridden by the user.
+  Temporarily switches Integrated and Smart modes to Hybrid when an external display is connected
+  to a dGPU-owned DRM connector. Hybrid and Manual modes are unchanged. The requested mode is
+  restored after disconnect.
   - **Type:** `b`
   - **Access:** Read/Write
 

--- a/docs/development/dbus.md
+++ b/docs/development/dbus.md
@@ -72,6 +72,14 @@
   - **Type:** `b`
   - **Access:** Read/Write
 
+- **`ExternalDisplayAutoSwitch`**
+  Makes the required GPU available when an external display is connected to a dGPU-owned DRM
+  connector. Manual mode remains active and temporarily unblocks that GPU; other modes switch to
+  Hybrid. The previous mode and GPU state are restored after disconnect unless explicitly
+  overridden by the user.
+  - **Type:** `b`
+  - **Access:** Read/Write
+
 ### Debug
 
 `org.opengamingcollective.cardwire.Debug`


### PR DESCRIPTION
# Description

Expose the `ExternalDisplayAutoSwitch` read/write D-Bus property and document its behavior. This provides the daemon API required by the GUI and CLI controls.

Related to #7

# TODO

- [x] Add zbus getter and setter for external_display_auto_switch
- [x] Document the new property

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
