### PR TITLE
feat(gui): Add toggle for external display auto-switch

### DIFF
--- a/crates/cardwire-gui/src/app.rs
+++ b/crates/cardwire-gui/src/app.rs
@@ -209,6 +209,25 @@ impl AppState {
                     },
                 );
             }
+            Message::UpdateExternalDisplaySetting(setting) => {
+                let conn = self.zbus_conn.clone();
+                return Task::perform(
+                    async move {
+                        conn.set_setting(DaemonSettings::ExternalDisplayAutoSwitch, setting, None)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        Ok((
+                            DaemonSettings::ExternalDisplayAutoSwitch,
+                            Some(setting),
+                            None::<Mode>,
+                        ))
+                    },
+                    |res| match res {
+                        Ok(res) => Message::FetchedSetting(Ok(res)),
+                        Err(err) => Message::FetchedSetting(Err(err)),
+                    },
+                );
+            }
             Message::UpdateGuiConfig(config) => return self.save_gui_config(config),
             Message::TrayReady(handle) => {
                 self.tray_handle = Some(handle);
@@ -307,6 +326,11 @@ impl AppState {
                         DaemonSettings::BattAutoSwitchMode => {
                             if let Some(new_mode) = val.2 {
                                 self.setting_state.battery_mode = Some(new_mode)
+                            }
+                        }
+                        DaemonSettings::ExternalDisplayAutoSwitch => {
+                            if let Some(new_val) = val.1 {
+                                self.setting_state.external_display_checked = new_val
                             }
                         }
                     }

--- a/crates/cardwire-gui/src/helpers/dbus.rs
+++ b/crates/cardwire-gui/src/helpers/dbus.rs
@@ -166,7 +166,8 @@ impl CardwireDbus {
         match setting {
             DaemonSettings::AutoApplyGpuState
             | DaemonSettings::ExpNvidiaBlock
-            | DaemonSettings::BattAutoSwitch => {
+            | DaemonSettings::BattAutoSwitch
+            | DaemonSettings::ExternalDisplayAutoSwitch => {
                 proxy.set_property(&setting.to_string(), state).await
             }
             DaemonSettings::BattAutoSwitchMode => {

--- a/crates/cardwire-gui/src/message.rs
+++ b/crates/cardwire-gui/src/message.rs
@@ -14,6 +14,7 @@ pub enum Message {
     UpdateStateSetting(bool),
     UpdateBatterySetting(bool),
     UpdateBatteryMode(Mode),
+    UpdateExternalDisplaySetting(bool),
     UpdateGuiConfig(GuiConfig),
     TrayReady(TrayHandle),
     TrayAction(TrayAction),

--- a/crates/cardwire-gui/src/models.rs
+++ b/crates/cardwire-gui/src/models.rs
@@ -134,6 +134,7 @@ pub struct SettingState {
     pub state_checked: bool,
     pub battery_checked: bool,
     pub battery_mode: Option<Mode>,
+    pub external_display_checked: bool,
     pub gui_config: crate::gui_config::GuiConfig,
 }
 
@@ -143,6 +144,7 @@ pub enum DaemonSettings {
     ExpNvidiaBlock,
     BattAutoSwitch,
     BattAutoSwitchMode,
+    ExternalDisplayAutoSwitch,
 }
 
 impl Display for DaemonSettings {
@@ -152,6 +154,9 @@ impl Display for DaemonSettings {
             DaemonSettings::ExpNvidiaBlock => write!(f, "ExperimentalNvidiaBlock"),
             DaemonSettings::BattAutoSwitch => write!(f, "BatteryAutoSwitch"),
             DaemonSettings::BattAutoSwitchMode => write!(f, "BatteryAutoSwitchMode"),
+            DaemonSettings::ExternalDisplayAutoSwitch => {
+                write!(f, "ExternalDisplayAutoSwitch")
+            }
         }
     }
 }

--- a/crates/cardwire-gui/src/subscription.rs
+++ b/crates/cardwire-gui/src/subscription.rs
@@ -149,6 +149,8 @@ trait CardwireConfig {
     fn battery_auto_switch(&self) -> zbus::Result<bool>;
     #[zbus(property)]
     fn battery_auto_switch_mode(&self) -> zbus::Result<u32>;
+    #[zbus(property)]
+    fn external_display_auto_switch(&self) -> zbus::Result<bool>;
 }
 
 fn config_sub() -> Subscription<Message> {
@@ -174,6 +176,8 @@ fn config_sub() -> Subscription<Message> {
             let mut config_switch_battery = proxy.receive_battery_auto_switch_changed().await;
             let mut config_switch_battery_mode =
                 proxy.receive_battery_auto_switch_mode_changed().await;
+            let mut config_external_display =
+                proxy.receive_external_display_auto_switch_changed().await;
 
             // Fetch the initial values once so the toggles render the real daemon state on
             // startup, before any change signal arrives
@@ -227,7 +231,15 @@ fn config_sub() -> Subscription<Message> {
                 }
                 Err(e) => warn!("Failed to fetch battery_auto_switch_mode: {}", e),
             }
-
+            if let Ok(state) = proxy.external_display_auto_switch().await {
+                let _ = output
+                    .send(Message::FetchedSetting(Ok((
+                        DaemonSettings::ExternalDisplayAutoSwitch,
+                        Some(state),
+                        None,
+                    ))))
+                    .await;
+            }
             loop {
                 select! {
                     // Exp nvidia block
@@ -271,6 +283,15 @@ fn config_sub() -> Subscription<Message> {
                                     Some(mode),
                                 )))).await;
                             }
+                        }
+                    },
+                    Some(change) = config_external_display.next() => {
+                        if let Ok(new_state) = change.get().await {
+                            let _ = output.send(Message::FetchedSetting(Ok((
+                                DaemonSettings::ExternalDisplayAutoSwitch,
+                                Some(new_state),
+                                None,
+                            )))).await;
                         }
                     },
                 }

--- a/crates/cardwire-gui/src/subscription.rs
+++ b/crates/cardwire-gui/src/subscription.rs
@@ -231,14 +231,17 @@ fn config_sub() -> Subscription<Message> {
                 }
                 Err(e) => warn!("Failed to fetch battery_auto_switch_mode: {}", e),
             }
-            if let Ok(state) = proxy.external_display_auto_switch().await {
-                let _ = output
-                    .send(Message::FetchedSetting(Ok((
-                        DaemonSettings::ExternalDisplayAutoSwitch,
-                        Some(state),
-                        None,
-                    ))))
-                    .await;
+            match proxy.external_display_auto_switch().await {
+                Ok(state) => {
+                    let _ = output
+                        .send(Message::FetchedSetting(Ok((
+                            DaemonSettings::ExternalDisplayAutoSwitch,
+                            Some(state),
+                            None,
+                        ))))
+                        .await;
+                }
+                Err(e) => warn!("Failed to fetch external_display_auto_switch: {}", e),
             }
             loop {
                 select! {

--- a/crates/cardwire-gui/src/ui.rs
+++ b/crates/cardwire-gui/src/ui.rs
@@ -922,6 +922,20 @@ pub fn daemon_setting_page<'a>(
                 ),
             ]
             .align_y(Alignment::Center),
+            row![
+                column![
+                    text("External display auto-switch")
+                        .size(15)
+                        .color(Color::from_rgb(0.95, 0.95, 0.95)),
+                    text("Use the required GPU for displays connected to dGPU-only ports.")
+                        .size(14)
+                        .color(Color::from_rgb(0.72, 0.72, 0.75)),
+                ],
+                horizontal(),
+                toggler(setting_state.external_display_checked)
+                    .on_toggle(Message::UpdateExternalDisplaySetting),
+            ]
+            .align_y(Alignment::Center),
         ]
         .spacing(16),
     )

--- a/crates/cardwire-gui/src/ui.rs
+++ b/crates/cardwire-gui/src/ui.rs
@@ -927,7 +927,7 @@ pub fn daemon_setting_page<'a>(
                     text("External display auto-switch")
                         .size(15)
                         .color(Color::from_rgb(0.95, 0.95, 0.95)),
-                    text("Use Hybrid for dGPU-owned displays while in Integrated or Smart mode.")
+                    text("Switch to Hybrid mode when a dGPU-owned display is connected while in Integrated or Smart mode.")
                         .size(14)
                         .color(Color::from_rgb(0.72, 0.72, 0.75)),
                 ],

--- a/crates/cardwire-gui/src/ui.rs
+++ b/crates/cardwire-gui/src/ui.rs
@@ -927,7 +927,7 @@ pub fn daemon_setting_page<'a>(
                     text("External display auto-switch")
                         .size(15)
                         .color(Color::from_rgb(0.95, 0.95, 0.95)),
-                    text("Use the required GPU for displays connected to dGPU-only ports.")
+                    text("Use Hybrid for dGPU-owned displays while in Integrated or Smart mode.")
                         .size(14)
                         .color(Color::from_rgb(0.72, 0.72, 0.75)),
                 ],


### PR DESCRIPTION
# Description

Add GUI support for the daemon's `ExternalDisplayAutoSwitch` setting. The GUI now loads the setting, tracks D-Bus changes, exposes a Settings toggle, and persists user changes through D-Bus.

When enabled, the daemon can switch to Hybrid mode for a dGPU-owned display connected while the system is in Integrated or Smart mode.

Related to #7

# TODO

- [x] Expose new monitor setting in dbus helper and daemon settings
- [x] Add message to update setting
- [x] Add toggle in settings page UI

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
