### PR TITLE
Implement font detection

### DIFF
--- a/crates/cardwire-gui/src/gtk_font.rs
+++ b/crates/cardwire-gui/src/gtk_font.rs
@@ -18,9 +18,7 @@ pub fn default_font() -> iced::Font {
 const GSETTINGS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
 fn query_gsettings() -> Option<String> {
-    use std::io::Read;
-    use std::process::Stdio;
-    use std::time::Instant;
+    use std::{io::Read, process::Stdio, time::Instant};
 
     let mut child = std::process::Command::new("gsettings")
         .args(["get", "org.gnome.desktop.interface", "font-name"])

--- a/crates/cardwire-gui/src/gtk_font.rs
+++ b/crates/cardwire-gui/src/gtk_font.rs
@@ -1,0 +1,75 @@
+pub fn default_font() -> iced::Font {
+    match query_gsettings() {
+        Some(raw) => {
+            let family = parse_family(&raw);
+            log::info!("Using GTK interface font: {family}");
+            // ugly leak hack
+            let name: &'static str = Box::leak(family.into_boxed_str());
+            iced::Font::with_name(name)
+        }
+        None => {
+            log::warn!("Could not read GTK font via gsettings, falling back to iced default");
+            iced::Font::DEFAULT
+        }
+    }
+}
+
+fn query_gsettings() -> Option<String> {
+    let output = std::process::Command::new("gsettings")
+        .args(["get", "org.gnome.desktop.interface", "font-name"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let s = String::from_utf8_lossy(&output.stdout);
+    // gsettings wraps the value in single quotes for WHATEVER reason
+    Some(s.trim().trim_matches('\'').to_string())
+}
+
+fn parse_family(gtk_font_name: &str) -> String {
+    // if it SOMEHOW has "Inter,  10" format
+    if let Some((family, _)) = gtk_font_name.split_once(',') {
+        return family.trim().to_string();
+    }
+
+    let parts: Vec<&str> = gtk_font_name.split_whitespace().collect();
+    match parts.as_slice() {
+        [] => "Sans".to_string(),
+        [name] => name.to_string(),
+        [.., last] => {
+            if last.parse::<f32>().is_ok() {
+                parts[..parts.len() - 1].join(" ")
+            } else {
+                gtk_font_name.to_string()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_family;
+
+    #[test]
+    fn parses_gnome_style() {
+        assert_eq!(parse_family("Adwaita Sans 11"), "Adwaita Sans");
+    }
+
+    #[test]
+    fn parses_gnome_style_with_weight() {
+        assert_eq!(parse_family("Ubuntu Bold 12"), "Ubuntu Bold");
+    }
+
+    #[test]
+    fn parses_kde_style() {
+        assert_eq!(parse_family("Inter,  10"), "Inter");
+    }
+
+    #[test]
+    fn handles_no_size() {
+        assert_eq!(parse_family("Sans"), "Sans");
+    }
+}

--- a/crates/cardwire-gui/src/gtk_font.rs
+++ b/crates/cardwire-gui/src/gtk_font.rs
@@ -29,9 +29,9 @@ fn query_gsettings() -> Option<String> {
 
     let deadline = Instant::now() + GSETTINGS_TIMEOUT;
     let status = loop {
-        match child.try_wait().ok()? {
-            Some(status) => break status,
-            None => {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
                 if Instant::now() >= deadline {
                     // murder this so we don't leave a zombie/orphan around.
                     let _ = child.kill();
@@ -39,6 +39,12 @@ fn query_gsettings() -> Option<String> {
                     return None;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            Err(_) => {
+                // something is wrong with the child handle itself
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
             }
         }
     };
@@ -53,11 +59,12 @@ fn query_gsettings() -> Option<String> {
     Some(stdout.trim().trim_matches('\'').to_string())
 }
 
-// needed for font family stripping
+// needed for font family stripping (Pango style/weight/stretch descriptors)
 const STYLE_TOKENS: &[&str] = &[
     "Bold",
     "Italic",
     "Oblique",
+    "Roman",
     "Regular",
     "Light",
     "Medium",
@@ -68,9 +75,18 @@ const STYLE_TOKENS: &[&str] = &[
     "Semi-Bold",
     "Extrabold",
     "Extra-Bold",
-    "Condensed",
+    "Ultrabold",
+    "Ultra-Bold",
     "Extralight",
+    "Extra-Light",
+    "Ultralight",
+    "Ultra-Light",
+    "Condensed",
 ];
+
+fn strip_px_suffix(token: &str) -> &str {
+    token.strip_suffix("px").unwrap_or(token)
+}
 
 fn strip_style_tokens(name: &str) -> String {
     let mut parts: Vec<&str> = name.split_whitespace().collect();
@@ -99,7 +115,7 @@ fn parse_family(gtk_font_name: &str) -> String {
         [] => "Sans".to_string(),
         [name] => name.to_string(),
         [.., last] => {
-            let family = if last.parse::<f32>().is_ok() {
+            let family = if strip_px_suffix(last).parse::<f32>().is_ok() {
                 parts[..parts.len() - 1].join(" ")
             } else {
                 gtk_font_name.to_string()
@@ -131,5 +147,25 @@ mod tests {
     #[test]
     fn handles_no_size() {
         assert_eq!(parse_family("Sans"), "Sans");
+    }
+
+    #[test]
+    fn parses_px_size_suffix() {
+        assert_eq!(parse_family("Ubuntu Bold 12px"), "Ubuntu");
+    }
+
+    #[test]
+    fn strips_ultra_bold() {
+        assert_eq!(parse_family("Cantarell Ultra-Bold 11"), "Cantarell");
+    }
+
+    #[test]
+    fn strips_extra_light() {
+        assert_eq!(parse_family("Roboto Extra-Light 10"), "Roboto");
+    }
+
+    #[test]
+    fn strips_roman() {
+        assert_eq!(parse_family("Times Roman 12"), "Times");
     }
 }

--- a/crates/cardwire-gui/src/gtk_font.rs
+++ b/crates/cardwire-gui/src/gtk_font.rs
@@ -14,25 +14,86 @@ pub fn default_font() -> iced::Font {
     }
 }
 
+// idk maybe this person has such a slow drive, but let it be one second, whatever
+const GSETTINGS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 fn query_gsettings() -> Option<String> {
-    let output = std::process::Command::new("gsettings")
+    use std::io::Read;
+    use std::process::Stdio;
+    use std::time::Instant;
+
+    let mut child = std::process::Command::new("gsettings")
         .args(["get", "org.gnome.desktop.interface", "font-name"])
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
         .ok()?;
 
-    if !output.status.success() {
+    let deadline = Instant::now() + GSETTINGS_TIMEOUT;
+    let status = loop {
+        match child.try_wait().ok()? {
+            Some(status) => break status,
+            None => {
+                if Instant::now() >= deadline {
+                    // murder this so we don't leave a zombie/orphan around.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        }
+    };
+
+    if !status.success() {
         return None;
     }
 
-    let s = String::from_utf8_lossy(&output.stdout);
+    let mut stdout = String::new();
+    child.stdout.take()?.read_to_string(&mut stdout).ok()?;
     // gsettings wraps the value in single quotes for WHATEVER reason
-    Some(s.trim().trim_matches('\'').to_string())
+    Some(stdout.trim().trim_matches('\'').to_string())
+}
+
+// needed for font family stripping
+const STYLE_TOKENS: &[&str] = &[
+    "Bold",
+    "Italic",
+    "Oblique",
+    "Regular",
+    "Light",
+    "Medium",
+    "Thin",
+    "Black",
+    "Heavy",
+    "Semibold",
+    "Semi-Bold",
+    "Extrabold",
+    "Extra-Bold",
+    "Condensed",
+    "Extralight",
+];
+
+fn strip_style_tokens(name: &str) -> String {
+    let mut parts: Vec<&str> = name.split_whitespace().collect();
+    while let Some(last) = parts.last() {
+        if STYLE_TOKENS.iter().any(|t| t.eq_ignore_ascii_case(last)) {
+            parts.pop();
+        } else {
+            break;
+        }
+    }
+    if parts.is_empty() {
+        name.to_string()
+    } else {
+        parts.join(" ")
+    }
 }
 
 fn parse_family(gtk_font_name: &str) -> String {
     // if it SOMEHOW has "Inter,  10" format
     if let Some((family, _)) = gtk_font_name.split_once(',') {
-        return family.trim().to_string();
+        return strip_style_tokens(family.trim());
     }
 
     let parts: Vec<&str> = gtk_font_name.split_whitespace().collect();
@@ -40,11 +101,12 @@ fn parse_family(gtk_font_name: &str) -> String {
         [] => "Sans".to_string(),
         [name] => name.to_string(),
         [.., last] => {
-            if last.parse::<f32>().is_ok() {
+            let family = if last.parse::<f32>().is_ok() {
                 parts[..parts.len() - 1].join(" ")
             } else {
                 gtk_font_name.to_string()
-            }
+            };
+            strip_style_tokens(&family)
         }
     }
 }
@@ -60,7 +122,7 @@ mod tests {
 
     #[test]
     fn parses_gnome_style_with_weight() {
-        assert_eq!(parse_family("Ubuntu Bold 12"), "Ubuntu Bold");
+        assert_eq!(parse_family("Ubuntu Bold 12"), "Ubuntu");
     }
 
     #[test]

--- a/crates/cardwire-gui/src/main.rs
+++ b/crates/cardwire-gui/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod gtk_font;
 mod gui_config;
 mod helpers;
 mod message;
@@ -27,5 +28,6 @@ fn main() -> iced::Result {
         .title(AppState::title)
         .theme(iced::Theme::Dark)
         .subscription(AppState::subscription)
+        .default_font(gtk_font::default_font())
         .run()
 }


### PR DESCRIPTION
# Description

Previously, the GUI was using iced's built-in default font and didn't care about user's settings at all. This PR makes cardwire-gui read the GTK interface font from GSettings and pass it to iced as the application default font.

Fixes # (uhh, no existing issue, I just straight up implemented this)

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)

I ran cargo fmt and HOLY MOLLY, there were a LOT of formatting fixes, so I decided not to touch any other files other than just mine.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation

Why would I, it's a minor change?

- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
