### PR TITLE
fix(cardwired): on monitor event, re-apply the persisted mode, replace change uevent to add/remove

### DIFF
--- a/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
+++ b/crates/cardwire-daemon/src/analyzer/dynamic_analysis.rs
@@ -9,26 +9,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader}, net::UnixStream
 };
 
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum Desktop {
-    Niri,
-    Gnome,
-    Plasma,
-    Cosmic,
-}
-
-impl Desktop {
-    fn from_str(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "niri" => Some(Desktop::Niri),
-            "gnome" => Some(Desktop::Gnome),
-            "plasma" => Some(Desktop::Plasma),
-            "cosmic" => Some(Desktop::Cosmic),
-            _ => None,
-        }
-    }
-}
+use crate::core::desktop::Desktop;
 
 pub fn get_steam_app_id(environ: &[u8]) -> Option<String> {
     let prefix = b"SteamAppId=";
@@ -187,21 +168,5 @@ mod tests {
         // "CARDWIRE_ALLOW=x" value at index 15 is 'x', not '1'
         let environ = b"CARDWIRE_ALLOW=x";
         assert_eq!(check_env("CARDWIRE_ALLOW", environ), None);
-    }
-
-    #[test]
-    fn test_desktop_from_str_all_known_variants() {
-        assert!(matches!(Desktop::from_str("niri"), Some(Desktop::Niri)));
-        assert!(matches!(Desktop::from_str("gnome"), Some(Desktop::Gnome)));
-        assert!(matches!(Desktop::from_str("plasma"), Some(Desktop::Plasma)));
-        assert!(matches!(Desktop::from_str("cosmic"), Some(Desktop::Cosmic)));
-    }
-
-    #[test]
-    fn test_desktop_from_str_unknown_returns_none() {
-        assert!(Desktop::from_str("sway").is_none());
-        assert!(Desktop::from_str("hyprland").is_none());
-        assert!(Desktop::from_str("i3").is_none());
-        assert!(Desktop::from_str("").is_none());
     }
 }

--- a/crates/cardwire-daemon/src/core/desktop.rs
+++ b/crates/cardwire-daemon/src/core/desktop.rs
@@ -1,4 +1,4 @@
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Desktop {
     Niri,

--- a/crates/cardwire-daemon/src/core/desktop.rs
+++ b/crates/cardwire-daemon/src/core/desktop.rs
@@ -1,0 +1,36 @@
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Desktop {
+    Niri,
+    Gnome,
+    Plasma,
+    Cosmic,
+}
+
+impl Desktop {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "niri" => Some(Desktop::Niri),
+            "gnome" => Some(Desktop::Gnome),
+            "plasma" => Some(Desktop::Plasma),
+            "cosmic" => Some(Desktop::Cosmic),
+            _ => None,
+        }
+    }
+}
+
+#[test]
+fn test_desktop_from_str_all_known_variants() {
+    assert!(matches!(Desktop::from_str("niri"), Some(Desktop::Niri)));
+    assert!(matches!(Desktop::from_str("gnome"), Some(Desktop::Gnome)));
+    assert!(matches!(Desktop::from_str("plasma"), Some(Desktop::Plasma)));
+    assert!(matches!(Desktop::from_str("cosmic"), Some(Desktop::Cosmic)));
+}
+
+#[test]
+fn test_desktop_from_str_unknown_returns_none() {
+    assert!(Desktop::from_str("sway").is_none());
+    assert!(Desktop::from_str("hyprland").is_none());
+    assert!(Desktop::from_str("i3").is_none());
+    assert!(Desktop::from_str("").is_none());
+}

--- a/crates/cardwire-daemon/src/core/desktop.rs
+++ b/crates/cardwire-daemon/src/core/desktop.rs
@@ -18,19 +18,23 @@ impl Desktop {
         }
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_desktop_from_str_all_known_variants() {
-    assert!(matches!(Desktop::from_str("niri"), Some(Desktop::Niri)));
-    assert!(matches!(Desktop::from_str("gnome"), Some(Desktop::Gnome)));
-    assert!(matches!(Desktop::from_str("plasma"), Some(Desktop::Plasma)));
-    assert!(matches!(Desktop::from_str("cosmic"), Some(Desktop::Cosmic)));
-}
+    #[test]
+    fn test_desktop_from_str_all_known_variants() {
+        assert!(matches!(Desktop::from_str("niri"), Some(Desktop::Niri)));
+        assert!(matches!(Desktop::from_str("gnome"), Some(Desktop::Gnome)));
+        assert!(matches!(Desktop::from_str("plasma"), Some(Desktop::Plasma)));
+        assert!(matches!(Desktop::from_str("cosmic"), Some(Desktop::Cosmic)));
+    }
 
-#[test]
-fn test_desktop_from_str_unknown_returns_none() {
-    assert!(Desktop::from_str("sway").is_none());
-    assert!(Desktop::from_str("hyprland").is_none());
-    assert!(Desktop::from_str("i3").is_none());
-    assert!(Desktop::from_str("").is_none());
+    #[test]
+    fn test_desktop_from_str_unknown_returns_none() {
+        assert!(Desktop::from_str("sway").is_none());
+        assert!(Desktop::from_str("hyprland").is_none());
+        assert!(Desktop::from_str("i3").is_none());
+        assert!(Desktop::from_str("").is_none());
+    }
 }

--- a/crates/cardwire-daemon/src/core/gpu/display.rs
+++ b/crates/cardwire-daemon/src/core/gpu/display.rs
@@ -151,8 +151,20 @@ pub async fn is_gpu_active(card: u32) -> Option<bool> {
     }
 }
 
-/// Send a "change" uevent for a DRM card, prompting the display server to
-/// rescan connectors.
-pub async fn send_drm_uevent(card: u32) -> io::Result<()> {
-    tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "change\n").await
+/// Uevent action sent to a DRM card.
+pub enum UdevAction {
+    Add,
+    Remove,
+}
+
+/// Send a uevent for a DRM card, prompting the display server to react to it.
+pub async fn send_drm_uevent(card: u32, action: UdevAction) -> io::Result<()> {
+    match action {
+        UdevAction::Add => {
+            tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "add\n").await
+        }
+        // Mutter has no device removal: a "remove" event only makes it rescan the blocked
+        // card, hitting its stale-pointer crash path. No-op until fixed upstream.
+        UdevAction::Remove => Ok(()),
+    }
 }

--- a/crates/cardwire-daemon/src/core/gpu/display.rs
+++ b/crates/cardwire-daemon/src/core/gpu/display.rs
@@ -1,8 +1,10 @@
 //! DRM display connector detection and node resolution.
 
 use log::{info, warn};
-use std::{fs, io, path::Path, time::Duration};
+use std::{env, fs, io, path::Path, time::Duration};
 use udev::{Device, Enumerator};
+
+use crate::core::desktop::Desktop;
 
 const NON_PHYSICAL: &[&str] = &["Virtual-", "Unknown-", "Writeback-"];
 const INTERNAL_PANELS: &[&str] = &["eDP-", "LVDS-", "DSI-", "DPI-", "SPI-"];
@@ -163,8 +165,23 @@ pub async fn send_drm_uevent(card: u32, action: UdevAction) -> io::Result<()> {
         UdevAction::Add => {
             tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "add\n").await
         }
-        // Mutter has no device removal: a "remove" event only makes it rescan the blocked
-        // card, hitting its stale-pointer crash path. No-op until fixed upstream.
-        UdevAction::Remove => Ok(()),
+        UdevAction::Remove => {
+            let desktop_str: String = match env::var("XDG_CURRENT_DESKTOP") {
+                Ok(value) => value,
+                Err(_) => return Ok(()),
+            };
+            let desktop: Desktop = match Desktop::from_str(&desktop_str) {
+                Some(v) => v,
+                None => return Ok(()),
+            };
+            match desktop {
+                // Mutter has no device removal: a "remove" event only makes it rescan the blocked
+                // card, hitting its stale-pointer crash path. No-op until fixed upstream.
+                Desktop::Gnome => Ok(()),
+                _ => {
+                    tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "remove\n").await
+                }
+            }
+        }
     }
 }

--- a/crates/cardwire-daemon/src/core/gpu/display.rs
+++ b/crates/cardwire-daemon/src/core/gpu/display.rs
@@ -170,17 +170,12 @@ pub async fn send_drm_uevent(card: u32, action: UdevAction) -> io::Result<()> {
                 Ok(value) => value,
                 Err(_) => return Ok(()),
             };
-            let desktop: Desktop = match Desktop::from_str(&desktop_str) {
-                Some(v) => v,
-                None => return Ok(()),
-            };
-            match desktop {
-                // Mutter has no device removal: a "remove" event only makes it rescan the blocked
-                // card, hitting its stale-pointer crash path. No-op until fixed upstream.
-                Desktop::Gnome => Ok(()),
-                _ => {
-                    tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "remove\n").await
-                }
+            // Mutter has no device removal: a "remove" event only makes it rescan the blocked
+            // card, hitting its stale-pointer crash path. No-op until fixed upstream.
+            if Desktop::from_str(&desktop_str).is_some_and(|d| d == Desktop::Gnome) {
+                Ok(())
+            } else {
+                tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "remove\n").await
             }
         }
     }

--- a/crates/cardwire-daemon/src/core/gpu/mod.rs
+++ b/crates/cardwire-daemon/src/core/gpu/mod.rs
@@ -9,7 +9,7 @@ mod vulkan;
 
 pub use default_gpu::check_default_drm_class;
 #[expect(unused_imports)]
-pub use display::{external_display_connected, is_gpu_active, send_drm_uevent};
+pub use display::{UdevAction, external_display_connected, is_gpu_active, send_drm_uevent};
 pub use enumerator::GpuEnumerator;
 pub use models::{DbusGpuDevice, GpuDevice, GpuVendor, PowerState};
 pub use nvidia::restart_nvidia_powerd;

--- a/crates/cardwire-daemon/src/core/mod.rs
+++ b/crates/cardwire-daemon/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod desktop;
 pub mod env;
 pub mod errors;
 pub mod gpu;

--- a/crates/cardwire-daemon/src/daemon.rs
+++ b/crates/cardwire-daemon/src/daemon.rs
@@ -24,6 +24,7 @@ pub const STATE_PATH: &str = "/var/lib/cardwire";
 async fn main() -> Result<()> {
     // log
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .filter_module("zbus", log::LevelFilter::Warn)
         .format_target(false)
         .format_timestamp(None)
         .init();

--- a/crates/cardwire-daemon/src/interface/gpu.rs
+++ b/crates/cardwire-daemon/src/interface/gpu.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     core::{
-        env::is_gpu_launchable, gpu::{DbusGpuDevice, GpuDevice, is_gpu_active, send_drm_uevent}, inode::{card_to_inode, get_inodes, nvidia_to_inode, render_to_inode, single_pci_to_inode}, pci::PciDevice, procfs
+        env::is_gpu_launchable, gpu::{DbusGpuDevice, GpuDevice, UdevAction, is_gpu_active, send_drm_uevent}, inode::{card_to_inode, get_inodes, nvidia_to_inode, render_to_inode, single_pci_to_inode}, pci::PciDevice, procfs
     }, file::{CardwireGpuState, CardwireModeState}, interface::{Modes, SwitcherooInterface}
 };
 use cardwire_ebpf_userspace::EbpfBlocker;
@@ -100,6 +100,13 @@ impl GpuInterface {
             blocker.block_inode(inode, value).into_fdo()?;
         }
 
+        if let Err(err) = send_drm_uevent(*self.device.card(), UdevAction::Remove).await {
+            warn!(
+                "failed to send drm uevent for {}: {err}",
+                self.device.name()
+            );
+        }
+
         Ok(())
     }
 
@@ -136,6 +143,12 @@ impl GpuInterface {
 
         for inode in inodes.iter() {
             blocker.unblock_inode(*inode, self.id).into_fdo()?;
+        }
+        if let Err(err) = send_drm_uevent(*self.device.card(), UdevAction::Add).await {
+            warn!(
+                "failed to send drm uevent for {}: {err}",
+                self.device.name()
+            );
         }
         Ok(())
     }
@@ -224,12 +237,6 @@ impl GpuInterface {
                     warn!("could not save gpu_state to file: {e}");
                 };
             }
-            if let Err(err) = send_drm_uevent(*self.device.card()).await {
-                warn!(
-                    "failed to send drm uevent for {}: {err}",
-                    self.device.name()
-                );
-            };
             // Refresh the switcheroo api
             self.switcheroo_int.emit_gpu_list_changed().await;
 
@@ -245,12 +252,6 @@ impl GpuInterface {
                     warn!("could not save gpu_state to file: {e}");
                 };
             }
-            if let Err(err) = send_drm_uevent(*self.device.card()).await {
-                warn!(
-                    "failed to send drm uevent for {}: {err}",
-                    self.device.name()
-                );
-            };
             // Refresh the switcheroo api
             self.switcheroo_int.emit_gpu_list_changed().await;
             Ok(())

--- a/crates/cardwire-daemon/src/interface/gpu.rs
+++ b/crates/cardwire-daemon/src/interface/gpu.rs
@@ -99,7 +99,7 @@ impl GpuInterface {
         for inode in inodes {
             blocker.block_inode(inode, value).into_fdo()?;
         }
-
+        drop(blocker);
         if let Err(err) = send_drm_uevent(*self.device.card(), UdevAction::Remove).await {
             warn!(
                 "failed to send drm uevent for {}: {err}",
@@ -144,6 +144,7 @@ impl GpuInterface {
         for inode in inodes.iter() {
             blocker.unblock_inode(*inode, self.id).into_fdo()?;
         }
+        drop(blocker);
         if let Err(err) = send_drm_uevent(*self.device.card(), UdevAction::Add).await {
             warn!(
                 "failed to send drm uevent for {}: {err}",

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -1,6 +1,6 @@
 //! Define the mode dbus
 use crate::{
-    core::gpu::{restart_nvidia_powerd, send_drm_uevent}, file::{CardwireGpuState, CardwireModeState}, interface::{DaemonContext, GpuInterface, SwitcherooInterface, config::ConfigMemory}, types::SystemType
+    core::gpu::restart_nvidia_powerd, file::{CardwireGpuState, CardwireModeState}, interface::{DaemonContext, GpuInterface, SwitcherooInterface, config::ConfigMemory}, types::SystemType
 };
 use anyhow::Result;
 use aya::maps::Array as AyaArray;
@@ -77,7 +77,7 @@ impl ModeInterface {
             warn!("failed to emit mode change signal: {err}");
         };
 
-        // Emit block_changed signal after the mode has been applied and send drm uevent
+        // Emit block_changed signal after the mode has been applied
         let gpu_list = self.gpu_list.read().await;
 
         for gpu in gpu_list.values().filter(|gpu| gpu.device.is_available()) {
@@ -89,9 +89,6 @@ impl ModeInterface {
                     gpu.device.name()
                 );
             }
-            if let Err(err) = send_drm_uevent(*gpu.device.card()).await {
-                warn!("failed to send drm uevent for {}: {err}", gpu.device.name());
-            };
         }
         // Drop the read lock before refreshing the switcheroo api
         drop(gpu_list);

--- a/crates/cardwire-daemon/src/tasks/monitor_display.rs
+++ b/crates/cardwire-daemon/src/tasks/monitor_display.rs
@@ -126,10 +126,14 @@ async fn run_display_monitor(
                 let mut guard = ready?;
                 if guard.ready().is_readable() {
                     // Drain the socket and collapse a burst of uevents into one reconciliation.
+                    // Real connector hotplug always surfaces as a "change" on the card. The
+                    // daemon's own "add" uevents are ignored here, so it never reconciles its
+                    // own mode switches; card "add"/"remove" (boot, dock unplug) is covered by
+                    // the periodic retry below.
                     for event in drm_fd.get_ref().iter() {
-                        if event.action().is_some_and(|action| {
-                            action == "add" || action == "remove" || action == "change"
-                        }) && let Some(card) = card_from_event(&event) {
+                        if event.action().is_some_and(|action| action == "change")
+                            && let Some(card) = card_from_event(&event)
+                        {
                             cards_seen.insert(card);
                         }
                     }

--- a/crates/cardwire-daemon/src/tasks/monitor_display.rs
+++ b/crates/cardwire-daemon/src/tasks/monitor_display.rs
@@ -59,16 +59,13 @@ async fn reconcile_gpu(
         warn!("failed to probe display state for card{card}; skipping reconcile");
         return;
     };
-    let Some(current_mode) = mode
-        .mode()
-        .await
-        .ok()
-        .and_then(|mode| Modes::try_from(mode).ok())
-    else {
+    // Reconcile against the persisted mode (the user's request), not the applied one, so the
+    // temporary Hybrid override can be restored once the display disconnects
+    let Ok(persisted) = CardwireModeState::build() else {
         return;
     };
 
-    match current_mode {
+    match persisted.mode() {
         // Integrated and Smart modes keep the offload dGPU blocked, except when it needs to
         // drive a connected display: then the effective mode is overridden to Hybrid.
         Modes::Integrated | Modes::Smart => {
@@ -88,10 +85,7 @@ async fn reconcile_gpu(
                 let _ = mode.internal_set_mode(Modes::Hybrid, false).await;
             } else if !active && !blocked {
                 // The override is in effect and the display is gone: restore the persisted mode
-                // from disk, since mode() now reports the applied override.
-                if let Ok(persisted) = CardwireModeState::build() {
-                    let _ = mode.internal_set_mode(persisted.mode(), false).await;
-                }
+                let _ = mode.internal_set_mode(persisted.mode(), false).await;
             }
         }
         // Manual mode leaves the user in control, except unblocking a GPU that suddenly


### PR DESCRIPTION
# Description

This PR fixes issues with the auto switch on monitor event:
- Re-apply the persisted mode on monitor event
- Send add/remove event instead of change event (remove is ignored for gnome)
- Monitor display now only listen for "change" events

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
