### PR TITLE
fix(docs): include service start for manual and other distros in install guide

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -133,8 +133,15 @@ Then clone and build:
 
 ```bash
 git clone https://github.com/OpenGamingCollective/cardwire.git
+
 make build
 sudo make install
+```
+
+And start the service:
+
+```bash
+sudo systemctl enable cardwired --now
 ```
 
 ## Other distros
@@ -154,4 +161,10 @@ git clone https://github.com/OpenGamingCollective/cardwire.git
 
 make build
 sudo make install
+```
+
+And start the service:
+
+```bash
+sudo systemctl enable cardwired --now
 ```


### PR DESCRIPTION
# Description

Add missing service start part for other distros and manual install in install guide of the mdbook

Fixes # (issue)

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
