### PR TITLE
fix(cardwired): start and stop nvidia-powerd depending on the mode

### DIFF
--- a/crates/cardwire-daemon/src/core/gpu/mod.rs
+++ b/crates/cardwire-daemon/src/core/gpu/mod.rs
@@ -12,4 +12,4 @@ pub use default_gpu::check_default_drm_class;
 pub use display::{external_display_connected, is_gpu_active, send_drm_uevent};
 pub use enumerator::GpuEnumerator;
 pub use models::{DbusGpuDevice, GpuDevice, GpuVendor, PowerState};
-pub use nvidia::restart_nvidia_powerd;
+pub use nvidia::{start_nvidia_powerd, stop_nvidia_powerd};

--- a/crates/cardwire-daemon/src/core/gpu/nvidia.rs
+++ b/crates/cardwire-daemon/src/core/gpu/nvidia.rs
@@ -68,22 +68,29 @@ pub async fn start_nvidia_powerd() {
 
 /// check whether the nvidia-powerd service is enabled
 async fn nvidia_powerd_enabled() -> bool {
-    match Command::new("systemctl")
-        .arg("is-enabled")
-        .arg(SERVICE)
-        .output()
-        .await
+    let output = match timeout(
+        Duration::from_secs(10),
+        Command::new("systemctl")
+            .arg("is-enabled")
+            .arg(SERVICE)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
     {
-        Ok(output) => {
-            if let Ok(output_str) = str::from_utf8(&output.stdout) {
-                output_str.contains("enabled")
-            } else {
-                false
-            }
-        }
-        Err(err) => {
+        Ok(Ok(output)) => output,
+        Ok(Err(err)) => {
             error!("error while trying to detect nvidia-powerd: {err}");
-            false
+            return false;
         }
+        Err(_) => {
+            error!("timed out after 10s while trying to detect nvidia-powerd");
+            return false;
+        }
+    };
+    if let Ok(output_str) = str::from_utf8(&output.stdout) {
+        output_str.contains("enabled")
+    } else {
+        false
     }
 }

--- a/crates/cardwire-daemon/src/core/gpu/nvidia.rs
+++ b/crates/cardwire-daemon/src/core/gpu/nvidia.rs
@@ -1,15 +1,76 @@
-use std::process::Stdio;
+use std::time::Duration;
 
 use log::{error, info, warn};
-use tokio::process::Command;
+use tokio::{process::Command, time::timeout};
 
-/// restart the nvidia-powerd service using systemctl
-pub async fn restart_nvidia_powerd() {
-    let service = "nvidia-powerd.service";
+const SERVICE: &str = "nvidia-powerd.service";
 
-    let enabled = match Command::new("systemctl")
+/// run a systemctl command against the nvidia-powerd service and log the result
+async fn run_systemctl(action: &str, extra_args: &[&str]) {
+    let output_cmd = Command::new("systemctl")
+        .arg(action)
+        .arg(SERVICE)
+        .args(extra_args)
+        .kill_on_drop(true)
+        .output();
+
+    let output = match timeout(Duration::from_secs(10), output_cmd).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(err)) => {
+            error!("error while trying to {action} nvidia-powerd: {err}");
+            return;
+        }
+        Err(_) => {
+            error!("timed out after 10s while trying to {action} nvidia-powerd");
+            return;
+        }
+    };
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if output.status.success() {
+        info!("successfully sent {action} on nvidia-powerd.service");
+    } else {
+        let code = output.status.code();
+        let detail = match code {
+            Some(code) => {
+                if stderr.is_empty() {
+                    format!("systemctl exited with code {code}")
+                } else {
+                    format!("systemctl exited with code {code}: {stderr}")
+                }
+            }
+            None => {
+                if stderr.is_empty() {
+                    "systemctl was terminated".to_string()
+                } else {
+                    format!("systemctl was terminated: {stderr}")
+                }
+            }
+        };
+        warn!("error while trying to {action} nvidia-powerd: {detail}");
+    }
+}
+
+/// stop the nvidia-powerd service using systemctl
+pub async fn stop_nvidia_powerd() {
+    if nvidia_powerd_enabled().await {
+        run_systemctl("stop", &[]).await;
+    }
+}
+
+/// start the nvidia-powerd service using systemctl, resetting its failed state first
+pub async fn start_nvidia_powerd() {
+    if nvidia_powerd_enabled().await {
+        run_systemctl("reset-failed", &[]).await;
+        run_systemctl("start", &[]).await;
+    }
+}
+
+/// check whether the nvidia-powerd service is enabled
+async fn nvidia_powerd_enabled() -> bool {
+    match Command::new("systemctl")
         .arg("is-enabled")
-        .arg(service)
+        .arg(SERVICE)
         .output()
         .await
     {
@@ -21,29 +82,8 @@ pub async fn restart_nvidia_powerd() {
             }
         }
         Err(err) => {
-            error!("error while trying to detect nvidia-powerd: {}", err);
-            return;
+            error!("error while trying to detect nvidia-powerd: {err}");
+            false
         }
-    };
-    if enabled {
-        match Command::new("systemctl")
-            .arg("restart")
-            .arg(service)
-            .arg("--no-block")
-            .stdout(Stdio::null())
-            .status()
-            .await
-        {
-            Ok(status) => {
-                if status.success() {
-                    info!("successfully restart nvidia-powerd.service");
-                } else {
-                    warn!("error restarting nvidia-powerd: {:?}", status.code())
-                }
-            }
-            Err(err) => {
-                error!("error while trying to restart nvidia-powerd: {}", err)
-            }
-        };
     }
 }

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -1,6 +1,6 @@
 //! Define the mode dbus
 use crate::{
-    core::gpu::{restart_nvidia_powerd, send_drm_uevent}, file::{CardwireGpuState, CardwireModeState}, interface::{DaemonContext, GpuInterface, SwitcherooInterface, config::ConfigMemory}, types::SystemType
+    core::gpu::{send_drm_uevent, start_nvidia_powerd, stop_nvidia_powerd}, file::{CardwireGpuState, CardwireModeState}, interface::{DaemonContext, GpuInterface, SwitcherooInterface, config::ConfigMemory}, types::SystemType
 };
 use anyhow::Result;
 use aya::maps::Array as AyaArray;
@@ -98,8 +98,14 @@ impl ModeInterface {
         // Refresh the switcheroo api
         self.switcheroo_int.emit_gpu_list_changed().await;
 
-        // and at last, try to restart nvidia-powerd, ignore if error, it will be logged
-        task::spawn(restart_nvidia_powerd());
+        match mode {
+            Modes::Hybrid | Modes::Manual => {
+                task::spawn(start_nvidia_powerd());
+            }
+            Modes::Integrated | Modes::Smart => {
+                task::spawn(stop_nvidia_powerd());
+            }
+        }
 
         Ok(())
     }

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -24,6 +24,8 @@ pub struct ModeInterface {
     mode_map: Arc<Mutex<AyaArray<aya::maps::MapData, u8>>>,
     // Mutex to serialize mode transitions
     transition: Arc<Mutex<()>>,
+    // Mutex to serialize nvidia-powerd start/stop operations
+    nvidia_powerd_lock: Arc<Mutex<()>>,
     // Signal emitter for mode changes (used by background tasks), populated once the interface is
     // served
     pub signal_emitter: Arc<OnceLock<SignalEmitter<'static>>>,
@@ -45,6 +47,7 @@ impl ModeInterface {
             config: context.config.clone(),
             mode_map,
             transition: Arc::new(Mutex::new(())),
+            nvidia_powerd_lock: Arc::new(Mutex::new(())),
             signal_emitter: Arc::new(OnceLock::new()),
             switcheroo_int,
         })
@@ -100,10 +103,18 @@ impl ModeInterface {
 
         match mode {
             Modes::Hybrid | Modes::Manual => {
-                task::spawn(start_nvidia_powerd());
+                let lock = self.nvidia_powerd_lock.clone();
+                task::spawn(async move {
+                    let _guard = lock.lock().await;
+                    start_nvidia_powerd().await;
+                });
             }
             Modes::Integrated | Modes::Smart => {
-                task::spawn(stop_nvidia_powerd());
+                let lock = self.nvidia_powerd_lock.clone();
+                task::spawn(async move {
+                    let _guard = lock.lock().await;
+                    stop_nvidia_powerd().await;
+                });
             }
         }
 


### PR DESCRIPTION
# Description

Start/Stop nvidia-powerd depending of the mode instead of always blindly restarting the service.
Also include a 10 secondes timeout, to prevent the task from being stuck on a non-responsive nvidia service

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
