### PR TITLE
fix: retry detecting discrete GPU solving boot race

### DIFF
--- a/crates/cardwire-daemon/src/core/gpu/enumerator.rs
+++ b/crates/cardwire-daemon/src/core/gpu/enumerator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap}, io, sync::Arc
+    collections::{BTreeMap, HashMap}, io, sync::Arc, time::Duration
 };
 
 use log::{error, info, warn};
@@ -123,17 +123,7 @@ impl GpuEnumerator {
             }
         };
 
-        // Skip the EGL probe for unavailable GPUs: the render node is unknown (u32::MAX) and the
-        // lookup would always fail on a phantom /dev/dri/renderD4294967295 path
-        let discrete = self.is_discrete_vulkan(device.pci_address())
-            || (available
-                && match is_discrete_egl(render) {
-                    Ok(discrete) => discrete,
-                    Err(err) => {
-                        warn!("{}: EGL discrete check failed: {}", device_name, err);
-                        false
-                    }
-                });
+        let discrete = self.is_discrete(device.pci_address(), render, available, &device_name);
 
         Ok(GpuDevice::new(
             device_name,
@@ -154,6 +144,54 @@ impl GpuEnumerator {
             && let Some(vlk_dev) = vlk_map.get(pci_id)
         {
             return vlk_dev.properties().device_type == PhysicalDeviceType::DiscreteGpu;
+        }
+
+        false
+    }
+    /// Determine whether a GPU is discrete, retrying both the Vulkan and EGL probes.
+    ///
+    /// At daemon startup these probes can race the NVIDIA/AMD driver stack coming up (the
+    /// GPU's DRM nodes may only just have appeared, see `drm_node_ids`'s own retry loop), so a
+    /// single failed attempt right after boot doesn't mean the GPU truly isn't discrete - it
+    /// means the ICD/EGL driver wasn't ready yet. Re-enumerate Vulkan fresh on each attempt since
+    /// the cached `vlk_physical_devices` snapshot was taken even earlier, at enumerator
+    /// construction time.
+    fn is_discrete(&self, pci_id: &str, render: u32, available: bool, device_name: &str) -> bool {
+        const MAX_RETRIES: u32 = 10;
+        const RETRY_INTERVAL: Duration = Duration::from_millis(500);
+
+        if self.is_discrete_vulkan(pci_id) {
+            return true;
+        }
+
+        // Skip the EGL probe for unavailable GPUs: the render node is unknown (u32::MAX) and the
+        // lookup would always fail on a phantom /dev/dri/renderD4294967295 path
+        if !available {
+            return false;
+        }
+
+        for attempt in 1..=MAX_RETRIES {
+            if attempt > 1
+                && let Some(vlk_dev) = vlk_enumerate().and_then(|map| map.get(pci_id).cloned())
+                && vlk_dev.properties().device_type == PhysicalDeviceType::DiscreteGpu
+            {
+                return true;
+            }
+
+            match is_discrete_egl(render) {
+                Ok(discrete) => return discrete,
+                Err(err) if attempt < MAX_RETRIES => {
+                    warn!(
+                        "{}: EGL discrete check failed, attempt {}/{MAX_RETRIES}, retrying in 500ms...: {}",
+                        device_name, attempt, err
+                    );
+                    std::thread::sleep(RETRY_INTERVAL);
+                }
+                Err(err) => {
+                    warn!("{}: EGL discrete check failed: {}", device_name, err);
+                    return false;
+                }
+            }
         }
 
         false


### PR DESCRIPTION
# Problem
Misclassifying nvidia discrete GPU as integrated and disabling Integrated/Smart modes.

# Context
Just updated my Asus G14 2025 Ubuntu 26.04 today and built latest cardwire from source.

Sidenote: Had to run the following to get it building because of https://github.com/OpenGamingCollective/cardwire/commit/c5e8dcda2700a987851f5d55ff56ca470d1b56ed:
```
rustup toolchain install nightly-2026-08-12 --component rust-src
cargo +nightly-2026-08-12 install --locked bpf-linker@0.10.4
```

After installing and rebooting the option "Integrated" which I'm using most of the time was missing from my AMD/nvidia GPU setup. Also the nvidia GPU was not listed as discrete (and blocked) anymore.

# Solution

I asked Claude for a solution and it quickly found that it's a boot race condition where cardwired is started before the nvidia driver is fully initialized. And the one Vulkan/EGL probe query for the nvidia GPU being dicrete returns an error and defaults to integrated instead.

Claude implemented a 10 times retry with 500ms in between for this discrete GPU probing.

# Testing

On my setup it seems to always scceed on the second try for the nvidia GPU. The AMD GPU produces the same error instead of reporting being "non-descrete", so it fails 10 times (5 seconds) before defaulting to integrated which is correct delaying the service start which has no side effect in my testing.

I had to manually set "Integrated" mode again after reboot because once cardwire fell back to "Hybrid" mode even just once it would keep that as the user selected option until "Integrated" is available and manually selected again.

# Possible alternatives

1. Delay the detection by I don't know how much time
2. Have a robust systemd hook for when all GPUs are initialized

Not sure if these are feasible/better.

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
   Corrects many other files.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
