### PR TITLE
chore: remove old systemd udev service

### DIFF
--- a/assets/cardwired.service
+++ b/assets/cardwired.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Cardwire Daemon
 After=dbus.service
-Wants=systemd-udev-settle.service
-After=systemd-udev-settle.service
 
 
 [Service]


### PR DESCRIPTION
# Description
Remove the deprecated systemd-udev-settle.service
Fixes #195 

# TODO

- [ ] Copy-Paste this line

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
