### PR TITLE
fix(cardwire-gui): prevent multiple instances and focus the running one on relaunch

### DIFF
--- a/crates/cardwire-gui/src/app.rs
+++ b/crates/cardwire-gui/src/app.rs
@@ -273,6 +273,7 @@ impl AppState {
                 }
             }
             Message::TrayShutdownComplete => return iced::exit(),
+            Message::ShowWindow => return self.open_or_focus_window(),
             Message::WindowClosed(id) => {
                 if self.window_id == Some(id) {
                     self.window_id = None;
@@ -536,6 +537,7 @@ impl AppState {
         Subscription::batch([
             crate::subscription::dbus_sub(),
             crate::subscription::tray_sub(),
+            crate::subscription::show_window_sub(),
             window::close_events().map(Message::WindowClosed),
         ])
     }

--- a/crates/cardwire-gui/src/main.rs
+++ b/crates/cardwire-gui/src/main.rs
@@ -4,18 +4,33 @@ mod gui_config;
 mod helpers;
 mod message;
 mod models;
+mod single_instance;
 mod subscription;
 mod tray;
 mod ui;
 
 use app::AppState;
 use env_logger::Env;
+use log::info;
 
-fn main() -> iced::Result {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format_target(false)
         .format_timestamp(None)
         .init();
+
+    // Keep alive for the process's lifetime: dropping it releases the D-Bus name and a
+    // subsequent launch would no longer detect this instance as running.
+    let _single_instance_guard = match single_instance::acquire() {
+        single_instance::Acquisition::Acquired(connection) => connection,
+        single_instance::Acquisition::AlreadyRunning => {
+            info!("cardwire-gui is already running; exiting");
+            return Ok(());
+        }
+        single_instance::Acquisition::Unchecked => {
+            return Err("could not determine whether cardwire-gui is already running".into());
+        }
+    };
 
     unsafe {
         // Vulkan wakes the dGPU
@@ -29,5 +44,7 @@ fn main() -> iced::Result {
         .theme(iced::Theme::Dark)
         .subscription(AppState::subscription)
         .default_font(gtk_font::default_font())
-        .run()
+        .run()?;
+
+    Ok(())
 }

--- a/crates/cardwire-gui/src/message.rs
+++ b/crates/cardwire-gui/src/message.rs
@@ -20,6 +20,7 @@ pub enum Message {
     TrayAction(TrayAction),
     TrayUnavailable(String),
     TrayShutdownComplete,
+    ShowWindow,
     WindowClosed(iced::window::Id),
     UpdateGpuPowerState(usize, String),
     UpdateBlockState(usize, bool),

--- a/crates/cardwire-gui/src/single_instance.rs
+++ b/crates/cardwire-gui/src/single_instance.rs
@@ -1,0 +1,42 @@
+use log::warn;
+use zbus::{Error, blocking::Connection, fdo::RequestNameFlags};
+
+pub(crate) const BUS_NAME: &str = "org.opengamingcollective.cardwire.Gui";
+pub(crate) const OBJECT_PATH: &str = "/org/opengamingcollective/cardwire/Gui";
+/// Signal a later launch broadcasts to ask the running instance to raise its window.
+pub(crate) const SHOW_SIGNAL: &str = "Show";
+
+pub enum Acquisition {
+    Acquired(Connection),
+    AlreadyRunning,
+    /// Could not be verified (e.g. no session bus available).
+    Unchecked,
+}
+
+pub fn acquire() -> Acquisition {
+    let connection = match Connection::session() {
+        Ok(connection) => connection,
+        Err(error) => {
+            warn!(
+                "could not connect to session bus to check for another running instance: {error}"
+            );
+            return Acquisition::Unchecked;
+        }
+    };
+
+    match connection.request_name_with_flags(BUS_NAME, RequestNameFlags::DoNotQueue.into()) {
+        Ok(_) => Acquisition::Acquired(connection),
+        Err(Error::NameTaken) => {
+            if let Err(error) =
+                connection.emit_signal(None::<&str>, OBJECT_PATH, BUS_NAME, SHOW_SIGNAL, &())
+            {
+                warn!("could not ask the running instance to show its window: {error}");
+            }
+            Acquisition::AlreadyRunning
+        }
+        Err(error) => {
+            warn!("could not request D-Bus name to check for another running instance: {error}");
+            Acquisition::Unchecked
+        }
+    }
+}

--- a/crates/cardwire-gui/src/subscription.rs
+++ b/crates/cardwire-gui/src/subscription.rs
@@ -12,7 +12,7 @@ use crate::{
     helpers::CardwireDbus, message::Message, models::{DaemonSettings, LogEntry, Mode, PciDevice}, tray
 };
 use zbus::{
-    Connection, Proxy, names::OwnedInterfaceName, proxy, zvariant::{OwnedObjectPath, OwnedValue}
+    Connection, MatchRule, MessageStream, Proxy, message::Type as MessageType, names::OwnedInterfaceName, proxy, zvariant::{OwnedObjectPath, OwnedValue}
 };
 
 pub fn tray_sub() -> Subscription<Message> {
@@ -51,6 +51,54 @@ pub fn tray_sub() -> Subscription<Message> {
             std::future::pending::<()>().await;
         })
     })
+}
+
+pub fn show_window_sub() -> Subscription<Message> {
+    Subscription::run_with("cardwire_show_window_subscription", |_id| {
+        stream::channel(1, |mut output: Sender<Message>| async move {
+            let connection = match Connection::session().await {
+                Ok(conn) => conn,
+                Err(error) => {
+                    warn!(
+                        "Failed to connect to D-Bus for show-window requests: {}",
+                        error
+                    );
+                    return;
+                }
+            };
+
+            let rule = match show_window_match_rule() {
+                Ok(rule) => rule,
+                Err(error) => {
+                    warn!("Failed to build show-window match rule: {}", error);
+                    return;
+                }
+            };
+
+            let mut signals = match MessageStream::for_match_rule(rule, &connection, None).await {
+                Ok(stream) => stream,
+                Err(error) => {
+                    warn!("Failed to listen for show-window requests: {}", error);
+                    return;
+                }
+            };
+
+            while signals.next().await.is_some() {
+                if output.send(Message::ShowWindow).await.is_err() {
+                    return;
+                }
+            }
+        })
+    })
+}
+
+fn show_window_match_rule() -> zbus::Result<MatchRule<'static>> {
+    Ok(MatchRule::builder()
+        .msg_type(MessageType::Signal)
+        .path(crate::single_instance::OBJECT_PATH)?
+        .interface(crate::single_instance::BUS_NAME)?
+        .member(crate::single_instance::SHOW_SIGNAL)?
+        .build())
 }
 
 // CardwireMode is used to listen to mode change signals


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

# Description

The GUI previously had no guard against launching more than one instance, and each launch spawned its own tray icon, resulting in it being possible to have duplicate icons in the system tray.

This adds single-instance enforcement using the session D-Bus: on startup, the GUI requests a well-known name (`org.opengamingcollective.cardwire.Gui`). If another instance already owns it, the new launch broadcasts a `Show` signal and exits immediately instead of starting a second tray icon/window. The already-running instance listens for that signal and raises its window, so relaunching the app (e.g. clicking the desktop icon again) now brings the existing window to front instead of silently doing nothing or spawning a duplicate.

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
