### PR TITLE
feat(cardwire-gui): add a launch command to hide the gui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,7 @@ name = "cardwire-gui"
 version = "0.12.1"
 dependencies = [
  "chrono",
+ "clap",
  "env_logger",
  "freedesktop-desktop-entry",
  "iced",

--- a/crates/cardwire-gui/Cargo.toml
+++ b/crates/cardwire-gui/Cargo.toml
@@ -24,6 +24,7 @@ toml.workspace = true
 xdg.workspace = true
 chrono.workspace = true
 freedesktop-desktop-entry.workspace = true
+clap.workspace = true
 
 [[bin]]
 name = "cardwire-gui"

--- a/crates/cardwire-gui/src/app.rs
+++ b/crates/cardwire-gui/src/app.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use iced::{
     Alignment, Element, Length::{Fill, Fixed}, Subscription, Task, widget::{column, container, row, stack}, window
 };
@@ -5,7 +6,7 @@ use log::error;
 use std::collections::BTreeMap;
 
 use crate::{
-    gui_config::{GuiConfig, PrimaryClickAction}, helpers::{CardwireDbus, GpuDevice}, message::Message, models::{
+    args::CardwireArgs, gui_config::{GuiConfig, PrimaryClickAction}, helpers::{CardwireDbus, GpuDevice}, message::Message, models::{
         DaemonSettings, LogState, MainState, Mode, Page, PciDevice, SettingState, SmartState
     }, tray::{self, TrayAction, TrayHandle}, ui::{self, daemon_setting_page, error_bar, info_bar, pci_page}
 };
@@ -44,9 +45,17 @@ impl AppState {
                 Some(format!("Could not load GUI settings: {error}")),
             ),
         };
-        let (window_id, open_window) = if gui_config.start_in_tray {
+        let args = CardwireArgs::parse();
+
+        println!("arg result: {:?}", args.background);
+        // Hide the GUI if launched with --background, or if the start_in_tray setting is set
+        let (window_id, open_window) = if args.background.is_some_and(|b| b)
+            || (args.background.is_none() && gui_config.start_in_tray)
+        {
+            println!("would hide gui");
             (None, Task::none())
         } else {
+            println!("would show gui");
             let (id, task) = window::open(default_window_settings());
             (Some(id), task.discard())
         };

--- a/crates/cardwire-gui/src/app.rs
+++ b/crates/cardwire-gui/src/app.rs
@@ -46,16 +46,12 @@ impl AppState {
             ),
         };
         let args = CardwireArgs::parse();
-
-        println!("arg result: {:?}", args.background);
         // Hide the GUI if launched with --background, or if the start_in_tray setting is set
         let (window_id, open_window) = if args.background.is_some_and(|b| b)
             || (args.background.is_none() && gui_config.start_in_tray)
         {
-            println!("would hide gui");
             (None, Task::none())
         } else {
-            println!("would show gui");
             let (id, task) = window::open(default_window_settings());
             (Some(id), task.discard())
         };

--- a/crates/cardwire-gui/src/args.rs
+++ b/crates/cardwire-gui/src/args.rs
@@ -1,0 +1,8 @@
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(version, about, long_about = None)]
+pub struct CardwireArgs {
+    #[arg(short, long, num_args = 0..=1, default_missing_value = "true")]
+    pub background: Option<bool>,
+}

--- a/crates/cardwire-gui/src/args.rs
+++ b/crates/cardwire-gui/src/args.rs
@@ -3,6 +3,6 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
 pub struct CardwireArgs {
-    #[arg(short, long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(short, long, num_args = 0..=1, default_missing_value = "true", help("starts the GUI in background"))]
     pub background: Option<bool>,
 }

--- a/crates/cardwire-gui/src/main.rs
+++ b/crates/cardwire-gui/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod args;
 mod gtk_font;
 mod gui_config;
 mod helpers;


### PR DESCRIPTION
# Description

Add clap to cardwire-gui
And add an argument `--background` to start the GUI in background or not if set

Fixes: #200 

<!---
If you used an LLM/AI, please let us know with either
Co-Authored-By:
or
Assisted-by:
-->

<!--- Uncomment if needed
# TODO

- [ ] Copy-Paste this line
-->

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
