### PR TITLE
feat(cardwired): implement 'add' and 'remove' uevent

### DIFF
--- a/crates/cardwire-daemon/src/core/errors.rs
+++ b/crates/cardwire-daemon/src/core/errors.rs
@@ -44,6 +44,9 @@ pub enum CardwireError {
     #[error("Error with state_file {0}: {1}")]
     CardwireStateError(String, serde_json::Error),
 
+    #[error("Couldn't find renderD{0}")]
+    DriRenderdNotFound(u32),
+
     // Mode errors
     #[error("unknown mode: {0}")]
     UnknownMode(u32),

--- a/crates/cardwire-daemon/src/core/gpu/display.rs
+++ b/crates/cardwire-daemon/src/core/gpu/display.rs
@@ -150,9 +150,3 @@ pub async fn is_gpu_active(card: u32) -> Option<bool> {
         None => Some(false),
     }
 }
-
-/// Send a "change" uevent for a DRM card, prompting the display server to
-/// rescan connectors.
-pub async fn send_drm_uevent(card: u32) -> io::Result<()> {
-    tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "change\n").await
-}

--- a/crates/cardwire-daemon/src/core/gpu/mod.rs
+++ b/crates/cardwire-daemon/src/core/gpu/mod.rs
@@ -5,11 +5,13 @@ mod egl;
 mod enumerator;
 mod models;
 mod nvidia;
+mod uevent;
 mod vulkan;
 
 pub use default_gpu::check_default_drm_class;
 #[expect(unused_imports)]
-pub use display::{external_display_connected, is_gpu_active, send_drm_uevent};
+pub use display::{external_display_connected, is_gpu_active};
 pub use enumerator::GpuEnumerator;
 pub use models::{DbusGpuDevice, GpuDevice, GpuVendor, PowerState};
 pub use nvidia::{start_nvidia_powerd, stop_nvidia_powerd};
+pub use uevent::{DrmUEvents, send_uevent_blocking};

--- a/crates/cardwire-daemon/src/core/gpu/uevent.rs
+++ b/crates/cardwire-daemon/src/core/gpu/uevent.rs
@@ -1,0 +1,60 @@
+use log::{error, info, warn};
+
+use crate::{Result, core::errors::CardwireError};
+use std::{
+    fmt::Display, fs::{File, write}, os::fd::{self, OwnedFd}, path::Path
+};
+
+/// List of drm uevents cardwire can send
+#[derive(Debug, PartialEq)]
+pub enum DrmUEvents {
+    Add,
+    Remove,
+}
+impl Display for DrmUEvents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Add => write!(f, "add"),
+            Self::Remove => write!(f, "remove"),
+        }
+    }
+}
+pub fn send_uevent_blocking(uevent: DrmUEvents, card_id: u32, render_id: u32) -> Result<()> {
+    // If it's an add event, we need to the GPU before sending the signal to allow the DE to
+    // detect it
+    // since it's an Owned fd, it should be dropped once the function ends
+    let _owned_gpu_fd = {
+        warn!("Waking up the GPU before sending add event...");
+        get_gpu_fd(render_id)?
+    };
+
+    info!("sending this event: {} to card: {}", uevent, card_id);
+    if let Err(err) = send_drm_uevent(&uevent, card_id) {
+        error!(
+            "Couldn't send drm uevent {} for card{}: {}",
+            uevent, card_id, err
+        );
+        return Err(err);
+    }
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+    Ok(())
+}
+
+/// Get a file descriptor of the GPU, this function is blocking and file descriptor must be dropped
+/// as fast as possible
+fn get_gpu_fd(render_id: u32) -> Result<fd::OwnedFd> {
+    let path = format!("/dev/dri/renderD{}", render_id);
+    let path = Path::new(&path);
+    if !path.exists() {
+        return Err(CardwireError::DriRenderdNotFound(render_id));
+    }
+    let render_fd = File::open(path)?;
+    Ok(OwnedFd::from(render_fd))
+}
+
+/// Send a "change" uevent for a DRM card, prompting the display server to
+/// rescan connectors.
+pub fn send_drm_uevent(uevent: &DrmUEvents, card: u32) -> Result<()> {
+    let msg = format!("{}\n", uevent);
+    write(format!("/sys/class/drm/card{card}/uevent"), msg).map_err(CardwireError::Io)
+}

--- a/crates/cardwire-daemon/src/interface/gpu.rs
+++ b/crates/cardwire-daemon/src/interface/gpu.rs
@@ -6,12 +6,12 @@ use std::{
 
 use crate::{
     Result, core::{
-        env::is_gpu_launchable, gpu::{DbusGpuDevice, GpuDevice, is_gpu_active, send_drm_uevent}, inode::{card_to_inode, get_inodes, nvidia_to_inode, render_to_inode, single_pci_to_inode}, pci::PciDevice, procfs
+        env::is_gpu_launchable, gpu::{DbusGpuDevice, DrmUEvents, GpuDevice, is_gpu_active, send_uevent_blocking}, inode::{card_to_inode, get_inodes, nvidia_to_inode, render_to_inode, single_pci_to_inode}, pci::PciDevice, procfs
     }, file::{CardwireGpuState, CardwireModeState}, interface::{Modes, SwitcherooInterface}
 };
 use cardwire_ebpf_userspace::{EbpfBlocker, InodeKey};
 use log::{info, warn};
-use tokio::sync::RwLock;
+use tokio::{sync::RwLock, task::spawn_blocking};
 use zbus::{fdo, interface, object_server::SignalEmitter};
 
 pub trait FdoResultExt<T> {
@@ -133,6 +133,36 @@ impl GpuInterface {
     pub async fn unblock_gpu(&self) -> fdo::Result<()> {
         self.sync_inodes(self.id, false).await
     }
+    /// Send a 'remove' drm uevent
+    pub async fn send_drm_remove(&self) {
+        let card = *self.device.card();
+        let render = *self.device.render();
+        if let Err(err) =
+            spawn_blocking(move || send_uevent_blocking(DrmUEvents::Remove, card, render))
+                .await
+                .unwrap()
+        {
+            warn!(
+                "failed to send drm uevent for {}: {err}",
+                self.device.name()
+            );
+        };
+    }
+    /// Send a 'add' drm uevent
+    pub async fn send_drm_add(&self) {
+        let card = *self.device.card();
+        let render = *self.device.render();
+        if let Err(err) =
+            spawn_blocking(move || send_uevent_blocking(DrmUEvents::Add, card, render))
+                .await
+                .unwrap()
+        {
+            warn!(
+                "failed to send drm uevent for {}: {err}",
+                self.device.name()
+            );
+        };
+    }
 
     pub async fn take_pushed_inodes(&self) -> Vec<InodeKey> {
         std::mem::take(&mut *self.pushed_inodes.write().await)
@@ -227,12 +257,6 @@ impl GpuInterface {
                     warn!("could not save gpu_state to file: {e}");
                 };
             }
-            if let Err(err) = send_drm_uevent(*self.device.card()).await {
-                warn!(
-                    "failed to send drm uevent for {}: {err}",
-                    self.device.name()
-                );
-            };
             // Refresh the switcheroo api
             self.switcheroo_int.emit_gpu_list_changed().await;
 
@@ -248,12 +272,6 @@ impl GpuInterface {
                     warn!("could not save gpu_state to file: {e}");
                 };
             }
-            if let Err(err) = send_drm_uevent(*self.device.card()).await {
-                warn!(
-                    "failed to send drm uevent for {}: {err}",
-                    self.device.name()
-                );
-            };
             // Refresh the switcheroo api
             self.switcheroo_int.emit_gpu_list_changed().await;
             Ok(())

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -1,7 +1,7 @@
 //! Define the mode dbus
 use crate::{
     Result, core::{
-        errors::CardwireError, gpu::{send_drm_uevent, start_nvidia_powerd, stop_nvidia_powerd}
+        errors::CardwireError, gpu::{start_nvidia_powerd, stop_nvidia_powerd}
     }, file::{CardwireGpuState, CardwireModeState}, interface::{DaemonContext, GpuInterface, SwitcherooInterface, config::ConfigMemory}, types::SystemType
 };
 use aya::maps::Array as AyaArray;
@@ -10,7 +10,7 @@ use std::{
     collections::BTreeMap, sync::{Arc, OnceLock, atomic::Ordering}
 };
 use tokio::{
-    sync::{Mutex, RwLock}, task
+    sync::{Mutex, RwLock}, task::{self}
 };
 use zbus::{fdo, interface, object_server::SignalEmitter};
 
@@ -81,7 +81,7 @@ impl ModeInterface {
             warn!("failed to emit mode change signal: {err}");
         };
 
-        // Emit block_changed signal after the mode has been applied and send drm uevent
+        // Emit block_changed signal after the mode has been applied
         let gpu_list = self.gpu_list.read().await;
 
         for gpu in gpu_list.values().filter(|gpu| gpu.device.is_available()) {
@@ -93,9 +93,6 @@ impl ModeInterface {
                     gpu.device.name()
                 );
             }
-            if let Err(err) = send_drm_uevent(*gpu.device.card()).await {
-                warn!("failed to send drm uevent for {}: {err}", gpu.device.name());
-            };
         }
         // Drop the read lock before refreshing the switcheroo api
         drop(gpu_list);
@@ -144,6 +141,9 @@ impl ModeInterface {
                 for (id, gpu) in gpu_list.iter().filter(|(_, gpu)| gpu.device.is_available()) {
                     if gpu.device.is_discrete() && !gpu.device.is_default() {
                         // Here we block the offload dGPU
+                        // we MUST send the drm remove before blocking it, else a compositor could
+                        // crash (eg: niri)
+                        gpu.send_drm_remove().await;
                         gpu.block_gpu(*id as u32).await?;
                     } else if mode == Modes::Smart
                         && gpu.device.is_default()
@@ -159,6 +159,7 @@ impl ModeInterface {
             Modes::Hybrid => {
                 for gpu in gpu_list.values().filter(|gpu| gpu.device.is_available()) {
                     gpu.unblock_gpu().await?;
+                    gpu.send_drm_add().await;
                 }
             }
 
@@ -185,12 +186,15 @@ impl ModeInterface {
                                 gpu.device.name()
                             );
                             gpu.unblock_gpu().await?;
+                            gpu.send_drm_add().await;
                         } else {
                             info!("blocking: {} ", gpu.device.pci().pci_address());
+                            gpu.send_drm_remove().await;
                             gpu.block_gpu(*id as u32).await?;
                         }
                     } else {
                         gpu.unblock_gpu().await?;
+                        gpu.send_drm_add().await;
                     }
                 }
             }


### PR DESCRIPTION
# Description

Send 'add' uevent on unblock and 'remove' uevent on block

This will be opt-in for now, and will be placed in the experimental section until its stabilized and battle-tested

Fixes # (issue)

<!---
If you used an LLM/AI, please let us know with either
Co-Authored-By:
or
Assisted-by:
-->

# TODO

- [x] Tested on Niri x NixOS
- [ ] Tested on KDE x NixOS
- [ ] Tested on Gnome x NixOS
- [ ] Tested on other distributions

# Checklist:

- [ ] My code follows the style guidelines of this project (cargo fmt)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the mdBook documentation
- [ ] My changes generate no new warnings (clippy/clang)
- [ ] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
