### PR TITLE
fix(cardwired): remove uevent sending

### DIFF
--- a/crates/cardwire-daemon/src/core/gpu/display.rs
+++ b/crates/cardwire-daemon/src/core/gpu/display.rs
@@ -150,9 +150,3 @@ pub async fn is_gpu_active(card: u32) -> Option<bool> {
         None => Some(false),
     }
 }
-
-/// Send a "change" uevent for a DRM card, prompting the display server to
-/// rescan connectors.
-pub async fn send_drm_uevent(card: u32) -> io::Result<()> {
-    tokio::fs::write(format!("/sys/class/drm/card{card}/uevent"), "change\n").await
-}

--- a/crates/cardwire-daemon/src/core/gpu/mod.rs
+++ b/crates/cardwire-daemon/src/core/gpu/mod.rs
@@ -9,7 +9,7 @@ mod vulkan;
 
 pub use default_gpu::check_default_drm_class;
 #[expect(unused_imports)]
-pub use display::{external_display_connected, is_gpu_active, send_drm_uevent};
+pub use display::{external_display_connected, is_gpu_active};
 pub use enumerator::GpuEnumerator;
 pub use models::{DbusGpuDevice, GpuDevice, GpuVendor, PowerState};
 pub use nvidia::{start_nvidia_powerd, stop_nvidia_powerd};

--- a/crates/cardwire-daemon/src/interface/gpu.rs
+++ b/crates/cardwire-daemon/src/interface/gpu.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     Result, core::{
-        env::is_gpu_launchable, gpu::{DbusGpuDevice, GpuDevice, is_gpu_active, send_drm_uevent}, inode::{card_to_inode, get_inodes, nvidia_to_inode, render_to_inode, single_pci_to_inode}, pci::PciDevice, procfs
+        env::is_gpu_launchable, gpu::{DbusGpuDevice, GpuDevice, is_gpu_active}, inode::{card_to_inode, get_inodes, nvidia_to_inode, render_to_inode, single_pci_to_inode}, pci::PciDevice, procfs
     }, file::{CardwireGpuState, CardwireModeState}, interface::{Modes, SwitcherooInterface}
 };
 use cardwire_ebpf_userspace::{EbpfBlocker, InodeKey};
@@ -227,12 +227,6 @@ impl GpuInterface {
                     warn!("could not save gpu_state to file: {e}");
                 };
             }
-            if let Err(err) = send_drm_uevent(*self.device.card()).await {
-                warn!(
-                    "failed to send drm uevent for {}: {err}",
-                    self.device.name()
-                );
-            };
             // Refresh the switcheroo api
             self.switcheroo_int.emit_gpu_list_changed().await;
 
@@ -248,12 +242,6 @@ impl GpuInterface {
                     warn!("could not save gpu_state to file: {e}");
                 };
             }
-            if let Err(err) = send_drm_uevent(*self.device.card()).await {
-                warn!(
-                    "failed to send drm uevent for {}: {err}",
-                    self.device.name()
-                );
-            };
             // Refresh the switcheroo api
             self.switcheroo_int.emit_gpu_list_changed().await;
             Ok(())

--- a/crates/cardwire-daemon/src/interface/mode.rs
+++ b/crates/cardwire-daemon/src/interface/mode.rs
@@ -1,7 +1,7 @@
 //! Define the mode dbus
 use crate::{
     Result, core::{
-        errors::CardwireError, gpu::{send_drm_uevent, start_nvidia_powerd, stop_nvidia_powerd}
+        errors::CardwireError, gpu::{start_nvidia_powerd, stop_nvidia_powerd}
     }, file::{CardwireGpuState, CardwireModeState}, interface::{DaemonContext, GpuInterface, SwitcherooInterface, config::ConfigMemory}, types::SystemType
 };
 use aya::maps::Array as AyaArray;
@@ -93,9 +93,6 @@ impl ModeInterface {
                     gpu.device.name()
                 );
             }
-            if let Err(err) = send_drm_uevent(*gpu.device.card()).await {
-                warn!("failed to send drm uevent for {}: {err}", gpu.device.name());
-            };
         }
         // Drop the read lock before refreshing the switcheroo api
         drop(gpu_list);


### PR DESCRIPTION
# Description
send_drm_uevent sends 'change' when it should sends 'add' and 'remove' depending of the GPU state. drop the uevent function for now

<!---
If you used an LLM/AI, please let us know with either
Co-Authored-By:
or
Assisted-by:
-->

<!--- Uncomment if needed
# TODO

- [ ] Copy-Paste this line
-->

# Checklist:

- [x] My code follows the style guidelines of this project (cargo fmt)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the mdBook documentation
- [x] My changes generate no new warnings (clippy/clang)
- [x] New and existing unit tests pass locally with my changes (either use nix flake check or wait for the ci)
